### PR TITLE
Fix stale structural tests after flux-drive -> flux-engine rename

### DIFF
--- a/tests/structural/test_generate_agents.py
+++ b/tests/structural/test_generate_agents.py
@@ -290,7 +290,7 @@ class TestRenderAgent:
         fm_with = yaml.safe_load(content_with[3:content_with.index("---", 3)])
         fm_without = yaml.safe_load(content_without[3:content_without.index("---", 3)])
 
-        assert fm_with["flux_gen_version"] == 5
+        assert fm_with["flux_gen_version"] == 6
         assert fm_without["flux_gen_version"] == 4
 
     def test_escalation_instruction_in_decision_lens(self):
@@ -403,7 +403,7 @@ class TestGenerateFromSpecs:
         report = generate_from_specs(project, specs_path)
 
         assert "bad-name" not in report["generated"]
-        assert any("must start with 'fd-'" in e for e in report["errors"])
+        assert any("does not match" in e for e in report["errors"])
 
     def test_invalid_json(self, tmp_path):
         """Invalid JSON specs produce error status."""

--- a/tests/structural/test_namespace.py
+++ b/tests/structural/test_namespace.py
@@ -46,23 +46,26 @@ def test_no_stale_clavain_refs_in_commands(project_root: Path):
 
 def test_agent_roster_uses_interflux_namespace(project_root: Path):
     """Agent roster uses interflux:review:fd-* namespace."""
-    roster = (project_root / "skills" / "flux-drive" / "references" / "agent-roster.md").read_text()
+    roster = (project_root / "skills" / "flux-engine" / "references" / "agent-roster.md").read_text()
     assert "interflux:review:fd-architecture" in roster
     assert "interflux:review:fd-safety" in roster
     assert "Plugin Agents (interflux)" in roster
 
 
 def test_launch_uses_interknow_mcp(project_root: Path):
-    """launch.md uses mcp__plugin_interknow_qmd__ prefix (qmd moved to interknow)."""
-    launch = (project_root / "skills" / "flux-drive" / "phases" / "launch.md").read_text()
-    assert "mcp__plugin_interknow_qmd__" in launch
-    assert "mcp__plugin_clavain_qmd__" not in launch
+    """qmd retrieval uses mcp__plugin_interknow_qmd__ prefix (qmd moved to interknow).
+
+    The qmd retrieval protocol was consolidated into
+    references/progressive-enhancements.md (launch.md references it)."""
+    enh = (project_root / "skills" / "flux-engine" / "references" / "progressive-enhancements.md").read_text()
+    assert "mcp__plugin_interknow_qmd__" in enh
+    assert "mcp__plugin_clavain_qmd__" not in enh
 
 
 def test_launch_uses_interknow_collection(project_root: Path):
-    """launch.md uses interknow qmd collection name."""
-    launch = (project_root / "skills" / "flux-drive" / "phases" / "launch.md").read_text()
-    assert '"interknow"' in launch
+    """qmd retrieval uses the interknow qmd collection name."""
+    enh = (project_root / "skills" / "flux-engine" / "references" / "progressive-enhancements.md").read_text()
+    assert '"interknow"' in enh
 
 
 def test_flux_drive_command_uses_interflux(project_root: Path):

--- a/tests/structural/test_skills.py
+++ b/tests/structural/test_skills.py
@@ -20,8 +20,8 @@ def test_skill_count(skills_dir):
         d for d in skills_dir.iterdir()
         if d.is_dir() and (d / "SKILL.md").exists()
     )
-    assert len(dirs) == 1, (
-        f"Expected 1 skill, found {len(dirs)}: {[d.name for d in dirs]}"
+    assert len(dirs) == 2, (
+        f"Expected 2 skills, found {len(dirs)}: {[d.name for d in dirs]}"
     )
 
 
@@ -42,7 +42,7 @@ def test_skill_has_frontmatter(skill_dir):
 
 def test_flux_drive_phases_exist(skills_dir):
     """flux-drive skill has all expected phase files."""
-    phases_dir = skills_dir / "flux-drive" / "phases"
+    phases_dir = skills_dir / "flux-engine" / "phases"
     expected = ["launch.md", "synthesize.md", "shared-contracts.md", "slicing.md", "cross-ai.md", "launch-codex.md"]
     for name in expected:
         assert (phases_dir / name).exists(), f"Missing phase: {name}"
@@ -50,7 +50,7 @@ def test_flux_drive_phases_exist(skills_dir):
 
 def test_flux_drive_references_exist(skills_dir):
     """flux-drive skill has reference files."""
-    refs_dir = skills_dir / "flux-drive" / "references"
+    refs_dir = skills_dir / "flux-engine" / "references"
     expected = ["agent-roster.md", "scoring-examples.md"]
     for name in expected:
         assert (refs_dir / name).exists(), f"Missing reference: {name}"
@@ -68,8 +68,8 @@ def test_flux_research_skill_removed(skills_dir):
 
 def test_flux_drive_launch_consumes_clavain_b2_routing_contract(skills_dir):
     """Flux launch must activate Clavain B2 routing at dispatch time."""
-    launch = (skills_dir / "flux-drive" / "phases" / "launch.md").read_text()
-    skill = (skills_dir / "flux-drive" / "SKILL.md").read_text()
+    launch = (skills_dir / "flux-engine" / "phases" / "launch.md").read_text()
+    skill = (skills_dir / "flux-engine" / "SKILL.md").read_text()
 
     assert "--phase=<phase>" in skill
     assert "CLAVAIN_COMPOSE_PLAN" in launch
@@ -83,7 +83,7 @@ def test_flux_drive_launch_consumes_clavain_b2_routing_contract(skills_dir):
 
 def test_flux_drive_codex_launch_records_fixed_tier_exception(skills_dir):
     """Codex launch must make the passive-v1 fixed-tier exception explicit."""
-    launch = (skills_dir / "flux-drive" / "phases" / "launch-codex.md").read_text()
+    launch = (skills_dir / "flux-engine" / "phases" / "launch-codex.md").read_text()
 
     assert "CLAVAIN_DISPATCH_PROFILE=clavain" in launch
     assert "--tier deep" in launch

--- a/tests/structural/test_slicing.py
+++ b/tests/structural/test_slicing.py
@@ -7,32 +7,37 @@ import pytest
 
 @pytest.fixture(scope="session")
 def slicing_path(project_root: Path) -> Path:
-    return project_root / "skills" / "flux-drive" / "phases" / "slicing.md"
+    return project_root / "skills" / "flux-engine" / "phases" / "slicing.md"
 
 
 @pytest.fixture(scope="session")
 def slicing_content(project_root: Path) -> str:
-    return (project_root / "skills" / "flux-drive" / "phases" / "slicing.md").read_text()
+    return (project_root / "skills" / "flux-engine" / "phases" / "slicing.md").read_text()
 
 
 @pytest.fixture(scope="session")
 def flux_drive_skill(project_root: Path) -> str:
-    return (project_root / "skills" / "flux-drive" / "SKILL.md").read_text()
+    return (project_root / "skills" / "flux-engine" / "SKILL.md").read_text()
 
 
 @pytest.fixture(scope="session")
 def launch_phase(project_root: Path) -> str:
-    return (project_root / "skills" / "flux-drive" / "phases" / "launch.md").read_text()
+    return (project_root / "skills" / "flux-engine" / "phases" / "launch.md").read_text()
+
+
+@pytest.fixture(scope="session")
+def prompt_template(project_root: Path) -> str:
+    return (project_root / "skills" / "flux-engine" / "references" / "prompt-template.md").read_text()
 
 
 @pytest.fixture(scope="session")
 def shared_contracts(project_root: Path) -> str:
-    return (project_root / "skills" / "flux-drive" / "phases" / "shared-contracts.md").read_text()
+    return (project_root / "skills" / "flux-engine" / "phases" / "shared-contracts.md").read_text()
 
 
 @pytest.fixture(scope="session")
 def synthesize_phase(project_root: Path) -> str:
-    return (project_root / "skills" / "flux-drive" / "phases" / "synthesize.md").read_text()
+    return (project_root / "skills" / "flux-engine" / "phases" / "synthesize.md").read_text()
 
 
 # --- slicing.md existence and structure ---
@@ -40,7 +45,7 @@ def synthesize_phase(project_root: Path) -> str:
 
 def test_slicing_file_exists(slicing_path: Path):
     """phases/slicing.md exists."""
-    assert slicing_path.exists(), "skills/flux-drive/phases/slicing.md is missing"
+    assert slicing_path.exists(), "skills/flux-engine/phases/slicing.md is missing"
 
 
 def test_slicing_has_both_modes(slicing_content: str):
@@ -111,7 +116,7 @@ def test_slicing_has_synthesis_rules(slicing_content: str):
 def test_slicing_has_report_template(slicing_content: str):
     """slicing.md has a slicing report template."""
     assert "Slicing report" in slicing_content
-    assert "Routing improvements" in slicing_content
+    assert "routing improvements" in slicing_content
 
 
 # --- Thresholds and overrides ---
@@ -134,7 +139,7 @@ def test_skill_mentions_input_type_diff(flux_drive_skill: str):
 def test_skill_has_diff_profile(flux_drive_skill: str):
     """SKILL.md contains a Diff Profile section."""
     assert "Diff Profile" in flux_drive_skill
-    assert "slicing_eligible" in flux_drive_skill
+    assert "slicing eligible" in flux_drive_skill
 
 
 def test_skill_detects_diff_content(flux_drive_skill: str):
@@ -157,9 +162,9 @@ def test_launch_references_slicing(launch_phase: str):
     assert "Step 2.1b" in launch_phase
 
 
-def test_launch_has_diff_to_review_section(launch_phase: str):
-    """launch.md has a Diff to Review prompt template section."""
-    assert "## Diff to Review" in launch_phase
+def test_launch_has_diff_to_review_section(prompt_template: str):
+    """references/prompt-template.md has a Diff to Review prompt template section."""
+    assert "## Diff to Review" in prompt_template
 
 
 def test_shared_contracts_references_slicing(shared_contracts: str):

--- a/tests/test-budget.sh
+++ b/tests/test-budget.sh
@@ -75,21 +75,21 @@ else
 fi
 
 # Test 8: references/budget.md documents the full Step 1.2c algorithm
-if grep -q "Step 1.2c" "${PLUGIN_DIR}/skills/flux-drive/references/budget.md"; then
+if grep -q "Step 1.2c" "${PLUGIN_DIR}/skills/flux-engine/references/budget.md"; then
   pass "references/budget.md documents Step 1.2c (budget cut)"
 else
   fail "references/budget.md missing Step 1.2c documentation"
 fi
 
 # Test 9: references/budget.md specifies the Est. Tokens triage column
-if grep -q "Est. Tokens" "${PLUGIN_DIR}/skills/flux-drive/references/budget.md"; then
+if grep -q "Est. Tokens" "${PLUGIN_DIR}/skills/flux-engine/references/budget.md"; then
   pass "Triage table includes Est. Tokens column"
 else
   fail "Triage table missing Est. Tokens column"
 fi
 
 # Test 10: synthesize.md references cost report
-if grep -q "Cost Report\|cost_report\|Step 3.4b" "${PLUGIN_DIR}/skills/flux-drive/phases/synthesize.md"; then
+if grep -q "Cost Report\|cost_report\|Step 3.4b" "${PLUGIN_DIR}/skills/flux-engine/phases/synthesize.md"; then
   pass "synthesize.md references cost report"
 else
   fail "synthesize.md missing cost report reference"

--- a/tests/test_cross_model_dispatch.bats
+++ b/tests/test_cross_model_dispatch.bats
@@ -17,7 +17,7 @@ bats_require_minimum_version 1.5.0
 setup() {
     CONFIG_DIR="${BATS_TEST_DIRNAME}/../config/flux-drive"
     SPEC_DIR="${BATS_TEST_DIRNAME}/../docs/spec/extensions"
-    PHASES_DIR="${BATS_TEST_DIRNAME}/../skills/flux-drive/phases"
+    PHASES_DIR="${BATS_TEST_DIRNAME}/../skills/flux-engine/phases"
 }
 
 # --- F1: Config activation ---


### PR DESCRIPTION
## Problem

The `test` CI job fails on `main` (and on every PR branch) because the structural test suite was never updated to track several intentional refactors. Most prominently, the skill directory was renamed `skills/flux-drive/` → `skills/flux-engine/`, but the tests still hard-code the old path, producing `FileNotFoundError` (11 failed, 17 errors).

This is the doc/test-drift that the analysis in #3 independently surfaced. Fixing it here keeps that PR analysis-only.

## Fix (tests only — no production code changed)

- **Path rename:** `skills/flux-drive/` → `skills/flux-engine/` across the test suite. `config/flux-drive/` and `commands/flux-drive.md` are **unchanged** in the repo, so those references are intentionally left alone.
- **Skill count:** `test_skill_count` now expects **2** skills (`flux-engine` + `flux-review-engine`), matching `CLAUDE.md`.
- **Relocated content:** assertions repointed to the files where content now lives — qmd/interknow protocol → `references/progressive-enhancements.md`; `## Diff to Review` template → `references/prompt-template.md`.
- **Reworded tokens:** `slicing_eligible` → `slicing eligible`; `Routing improvements` → `routing improvements`.
- **`test_generate_agents` drift (unrelated to the rename, also pre-existing):** `FLUX_GEN_VERSION` expectation `5` → `6`; invalid-name assertion updated to the current path-traversal-safe regex message (`does not match`).

## Verification

```
cd tests && uv run pytest -q
# 160 passed   (was: 11 failed, 132 passed, 17 errors)
```

https://claude.ai/code/session_01VBqxaqMHtjoGXFuS1d4ui2

---
_Generated by [Claude Code](https://claude.ai/code/session_01VBqxaqMHtjoGXFuS1d4ui2)_