### PR TITLE
Add structural grounding check for synthesis output (closes #10)

### DIFF
--- a/scripts/verify-synthesis-grounding.sh
+++ b/scripts/verify-synthesis-grounding.sh
@@ -1,0 +1,227 @@
+#!/usr/bin/env bash
+# verify-synthesis-grounding.sh — structural grounding check for synthesized findings (issue #10, C-5)
+#
+# Synthesis (synthesize.md Step 3.2) delegates ALL collection, dedup, conflict detection,
+# and verdict-writing to a single haiku-tier synthesis subagent, and the host is told never
+# to read agent output files. Nothing verifies that a finding (ID + severity) in the
+# synthesized findings.json traces back to a real agent's machine-parseable Findings Index
+# entry. A synthesizer can therefore blend or invent findings ("invented coastline") undetected.
+#
+# This script is a cheap, deterministic post-synthesis assertion: every finding ID + severity
+# in findings.json must be grounded in some agent's Findings Index entry. Ungrounded findings
+# are reported; the severity policy below decides the exit code.
+#
+# Usage: verify-synthesis-grounding.sh <OUTPUT_DIR> [--run-uuid <uuid>] [--strict] [--json]
+#
+# Grammar (mirrors findings-helper.sh read-indexes grammar + shared-contracts.md §Findings Index):
+#   ### Findings Index
+#   - SEVERITY | ID | "Section Name" | Title
+#   Verdict: safe|needs-changes|risky
+# The synthesis-side anchored severity regex matches `^-\s*([Pp][0-9]+)\s*\|`. We match this
+# bullet shape directly against each trusted agent file rather than first carving out the
+# heading block: the `- P0 | ID | ...` pipe-delimited bullet shape is unique to the Findings
+# Index (prose "Issues Found" entries are numbered "1." not `- Pn |`), and matching the bullet
+# directly avoids depending on `{2,4}` interval-quantifier awk (unsupported by mawk).
+#
+# Grounding key: uppercased "<SEVERITY>|<ID>" (e.g. "P0|P0-1"). A synthesized finding is
+# grounded iff some agent index entry has the same severity AND id. ID-only match with a
+# different severity is reported separately as a severity-mismatch (the synthesizer may have
+# legitimately escalated via dedup rule 4 "use highest", so by default this is a warning, not a
+# failure, unless --strict).
+#
+# Quire-mark (issue #6): agent files carry `<!-- run-uuid: {uuid} -->` as the first non-empty
+# line. When --run-uuid is supplied (or FLUX_RUN_UUID is set), files whose marker is missing or
+# mismatched are treated as Foreign and excluded from the grounding corpus — exactly as
+# synthesize.md Step 3.1 does — so a stale prior-run file cannot launder an invented finding.
+#
+# Failure policy (default): exit 3 if any P0 or P1 synthesized finding is ungrounded; exit 0
+# (warn only) if only P2+ findings are ungrounded. Rationale: an ungrounded P0/P1 is a
+# fabricated blocking verdict and must fail the run; ungrounded P2 nits are lower-stakes noise.
+# With --strict, ANY ungrounded finding (any severity) or any severity-mismatch fails (exit 3).
+#
+# Exit codes: 0 ok (or warn-only) | 2 invalid invocation / missing inputs | 3 grounding violation
+set -euo pipefail
+
+usage() {
+  echo "Usage: verify-synthesis-grounding.sh <OUTPUT_DIR> [--run-uuid <uuid>] [--strict] [--json]" >&2
+  exit 2
+}
+
+output_dir="${1:-}"
+[[ -z "$output_dir" ]] && usage
+shift || true
+
+run_uuid="${FLUX_RUN_UUID:-}"
+strict=0
+emit_json=0
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --run-uuid) run_uuid="${2:-}"; shift 2 ;;
+    --strict)   strict=1; shift ;;
+    --json)     emit_json=1; shift ;;
+    *) echo "Unknown arg: $1" >&2; usage ;;
+  esac
+done
+
+if [[ ! -d "$output_dir" ]]; then
+  echo "Error: OUTPUT_DIR '$output_dir' not found" >&2
+  exit 2
+fi
+
+findings_json="$output_dir/findings.json"
+if [[ ! -f "$findings_json" ]]; then
+  echo "Error: findings.json not found in '$output_dir'" >&2
+  exit 2
+fi
+
+# --- 1. Build the grounded corpus from agent Findings Index lines -------------------------
+# Iterate the agent output files (same exclusion set as findings-helper.sh read-indexes:
+# synthesis outputs + reaction files are not agent findings). For each trusted file, harvest
+# every `- SEVERITY | ID | ...` bullet — the machine-parseable Findings Index grammar.
+#
+# Quire-mark filter (issue #6): when run_uuid is known, files whose first non-empty line is not
+# `<!-- run-uuid: {uuid} -->` are Foreign and excluded — a stale prior-run file cannot launder
+# an invented finding into the grounded corpus.
+all_index_lines=""
+foreign_count=0
+for f in "$output_dir"/*.md; do
+  [[ -f "$f" ]] || continue
+  base=$(basename "$f" .md)
+  case "$base" in
+    summary|synthesis|findings) continue ;;
+    *.reactions|*.reactions.error) continue ;;
+  esac
+  if [[ -n "$run_uuid" ]]; then
+    first_line=$(awk 'NF{print; exit}' "$f")
+    if [[ "$first_line" != "<!-- run-uuid: ${run_uuid} -->" ]]; then
+      foreign_count=$((foreign_count + 1))
+      continue
+    fi
+  fi
+  all_index_lines+=$(cat "$f")$'\n'
+done
+
+# grounded_keys: "SEVERITY|ID" ; grounded_ids: bare IDs (for severity-mismatch detection).
+# mawk-compatible: [Pp][0-9]+ only, no interval quantifiers.
+grounded_keys=$(printf '%s' "$all_index_lines" | awk '
+  {
+    line = $0
+    # Anchored severity at start of an index bullet: ^-\s*([Pp][0-9]+)\s*\|
+    if (line ~ /^-[ \t]*[Pp][0-9]+[ \t]*\|/) {
+      if (match(line, /[Pp][0-9]+/)) sev = toupper(substr(line, RSTART, RLENGTH)); else next
+      nf = split(line, parts, "|")
+      if (nf < 2) next
+      id = parts[2]
+      gsub(/^[ \t]+|[ \t]+$/, "", id)
+      if (id == "") next
+      print sev "|" id
+    }
+  }
+' | sort -u)
+
+grounded_ids=$(printf '%s' "$grounded_keys" | awk -F'|' 'NF>=2 {print $2}' | sort -u)
+
+# --- 2. Extract synthesized findings (id + severity) from findings.json --------------------
+synth_findings=$(jq -r '
+  (.findings // [])[]
+  | select((.id // "") != "")
+  | ((.severity // "") | ascii_upcase) + "|" + (.id|tostring)
+' "$findings_json" 2>/dev/null || true)
+
+if [[ -z "$synth_findings" ]]; then
+  # No findings to ground — vacuously OK.
+  if [[ "$emit_json" -eq 1 ]]; then
+    jq -n --argjson foreign "$foreign_count" \
+      '{status:"ok", checked:0, ungrounded:[], severity_mismatch:[], foreign_skipped:$foreign}'
+  else
+    echo "grounding: OK — 0 synthesized findings to verify (${foreign_count} foreign files skipped)"
+  fi
+  exit 0
+fi
+
+# --- 3. Classify each synthesized finding -------------------------------------------------
+ungrounded=()          # "SEVERITY|ID" — no index entry with this id at all
+sev_mismatch=()        # "SEVERITY|ID" — id exists in some index but with a different severity
+checked=0
+while IFS= read -r key; do
+  [[ -z "$key" ]] && continue
+  checked=$((checked + 1))
+  sev="${key%%|*}"
+  id="${key#*|}"
+  if printf '%s\n' "$grounded_keys" | grep -qxF "$key"; then
+    continue  # exact severity+id grounded
+  fi
+  if printf '%s\n' "$grounded_ids" | grep -qxF "$id"; then
+    sev_mismatch+=("$key")   # id present, severity differs (possibly escalated by dedup rule 4)
+  else
+    ungrounded+=("$key")     # id absent from every trusted index — fabricated
+  fi
+done <<< "$synth_findings"
+
+# --- 4. Apply failure policy --------------------------------------------------------------
+violation=0
+blocking_ungrounded=()
+for key in "${ungrounded[@]:-}"; do
+  [[ -z "$key" ]] && continue
+  sev="${key%%|*}"
+  if [[ "$strict" -eq 1 ]]; then
+    violation=1; blocking_ungrounded+=("$key")
+  elif [[ "$sev" == "P0" || "$sev" == "P1" ]]; then
+    violation=1; blocking_ungrounded+=("$key")
+  fi
+done
+if [[ "$strict" -eq 1 && "${#sev_mismatch[@]}" -gt 0 ]]; then
+  violation=1
+fi
+
+# --- 5. Report ----------------------------------------------------------------------------
+if [[ "$emit_json" -eq 1 ]]; then
+  ung_json=$(printf '%s\n' "${ungrounded[@]:-}" | sed '/^$/d' | jq -R . | jq -s .)
+  mm_json=$(printf '%s\n' "${sev_mismatch[@]:-}" | sed '/^$/d' | jq -R . | jq -s .)
+  status="ok"
+  if [[ "$violation" -eq 1 ]]; then
+    status="violation"
+  elif [[ "${#ungrounded[@]}" -gt 0 || "${#sev_mismatch[@]}" -gt 0 ]]; then
+    status="warn"
+  fi
+  jq -n \
+    --arg status "$status" \
+    --argjson checked "$checked" \
+    --argjson ungrounded "$ung_json" \
+    --argjson severity_mismatch "$mm_json" \
+    --argjson foreign "$foreign_count" \
+    --argjson strict "$strict" \
+    '{status:$status, checked:$checked, ungrounded:$ungrounded, severity_mismatch:$severity_mismatch, foreign_skipped:$foreign, strict:($strict==1)}'
+else
+  if [[ "$violation" -eq 1 ]]; then
+    echo "grounding: VIOLATION — synthesized findings not backed by any agent Findings Index entry:" >&2
+    for key in "${blocking_ungrounded[@]:-}"; do
+      [[ -z "$key" ]] && continue
+      echo "  - ungrounded: ${key%%|*} ${key#*|} (no index entry with this id)" >&2
+    done
+    if [[ "$strict" -eq 1 ]]; then
+      for key in "${sev_mismatch[@]:-}"; do
+        [[ -z "$key" ]] && continue
+        echo "  - severity-mismatch: ${key%%|*} ${key#*|} (id exists in an index under a different severity)" >&2
+      done
+    fi
+  else
+    echo "grounding: OK — ${checked} synthesized findings verified against agent indexes (${foreign_count} foreign files skipped)"
+  fi
+  # Non-fatal advisories
+  if [[ "$strict" -eq 0 ]]; then
+    for key in "${ungrounded[@]:-}"; do
+      [[ -z "$key" ]] && continue
+      sev="${key%%|*}"
+      [[ "$sev" == "P0" || "$sev" == "P1" ]] && continue
+      echo "grounding: warn — ungrounded ${sev} finding ${key#*|} (below blocking threshold)" >&2
+    done
+    for key in "${sev_mismatch[@]:-}"; do
+      [[ -z "$key" ]] && continue
+      echo "grounding: warn — ${key%%|*} ${key#*|} grounded by id but severity differs from index (possible dedup escalation)" >&2
+    done
+  fi
+fi
+
+[[ "$violation" -eq 1 ]] && exit 3
+exit 0

--- a/skills/flux-engine/phases/synthesize.md
+++ b/skills/flux-engine/phases/synthesize.md
@@ -128,6 +128,25 @@ Per the Synthesis Delegation contract (`docs/spec/contracts/synthesis-delegation
 
 The degraded path **deliberately drops the discourse layer** (reactions, Lorenzen move validation, stemma, sycophancy, DWSQ, diverse perspectives) — those are synthesizer-only. The core verdict and headline findings are preserved. Then continue at Step 3.4 (review) / Step 3.5-research (research).
 
+### Step 3.2b: Structural grounding check [review only] — MANDATORY
+
+The synthesis subagent (Step 3.2) is the *only* reader of agent prose, and the host is told never to open agent output files. Nothing else verifies that the findings the subagent wrote into `findings.json` actually trace back to a real agent's machine-parseable Findings Index — so a hallucinated or blended finding ("invented coastline") would otherwise reach the user with a fabricated P0/P1 verdict. This step closes that gap with a cheap, deterministic check the host runs *itself* (it reads only the structured Findings Index bullets via the script, never prose):
+
+```bash
+FLUX_RUN_UUID="${FLUX_RUN_UUID}" \
+  bash "${CLAUDE_PLUGIN_ROOT}/scripts/verify-synthesis-grounding.sh" "{OUTPUT_DIR}"
+grounding_status=$?
+```
+
+What it asserts: every `(severity, id)` pair in `findings.json` is grounded in some agent's Findings Index entry (`- SEVERITY | ID | "Section" | Title`, matched by the anchored bullet regex `^-\s*([Pp][0-9]+)\s*\|`), restricted to files carrying the current run's quire-mark (Foreign files from prior/concurrent runs are excluded, exactly as Step 3.1).
+
+**Failure policy:**
+- **Exit 3 (grounding violation):** at least one **P0 or P1** synthesized finding has no backing index entry. This is a fabricated blocking verdict. **Do not present the synthesis as-is.** Re-run the synthesis subagent once (Step 3.2); if the violation persists, surface it to the user explicitly — list the ungrounded finding IDs and note that synthesis could not be structurally verified — and degrade the verdict (do not assert `risky`/`needs-changes` on the strength of an unverifiable finding).
+- **Exit 0 with warnings (P2+ ungrounded, or `severity-mismatch`):** non-blocking. A `severity-mismatch` (id present but severity differs) is an expected outcome of dedup rule 4 ("conflicting severity → use highest"). Note warnings in the run log; proceed.
+- **Exit 2 (bad invocation / missing findings.json):** treat as a synthesis failure — `findings.json` should exist by this point.
+
+Pass `--strict` to fail on *any* ungrounded finding (any severity) or any severity-mismatch; `--json` for machine-readable output (consumed by post-mortem tooling).
+
 ### Step 3.3: (Handled by synthesis subagent)
 
 Deduplication, convergence tracking, conflict detection, and cognitive agent dedup are all performed by the synthesis subagent above. The 5 dedup rules (defined in `docs/spec/core/synthesis.md` Step 3) are executed in the subagent's context:

--- a/tests/structural/test_verify_synthesis_grounding.py
+++ b/tests/structural/test_verify_synthesis_grounding.py
@@ -1,0 +1,168 @@
+"""Tests for scripts/verify-synthesis-grounding.sh (issue #10, finding C-5).
+
+The synthesis subagent is the sole reader of agent prose and the host never opens
+agent output files, so an invented or blended finding in findings.json would reach
+the user undetected. verify-synthesis-grounding.sh asserts every (severity, id) pair
+in findings.json is backed by a real agent's machine-parseable Findings Index entry.
+"""
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent.parent
+SCRIPT = ROOT / "scripts" / "verify-synthesis-grounding.sh"
+
+RUN = "RUN-UUID-1"
+
+
+def _agent_file(d: Path, name: str, index_lines: list[str], run_uuid: str = RUN) -> None:
+    """Write an agent output .md file with a quire-mark and a Findings Index block."""
+    body = [f"<!-- run-uuid: {run_uuid} -->", "### Findings Index", *index_lines, "Verdict: risky"]
+    (d / f"{name}.md").write_text("\n".join(body) + "\n")
+
+
+def _findings_json(d: Path, findings: list[dict]) -> None:
+    (d / "findings.json").write_text(json.dumps({"findings": findings, "verdict": "risky"}))
+
+
+def _run(output_dir: Path, *args, run_uuid: str = RUN):
+    env_prefix = {"FLUX_RUN_UUID": run_uuid} if run_uuid is not None else {}
+    import os
+
+    env = {**os.environ, **env_prefix}
+    return subprocess.run(
+        ["bash", str(SCRIPT), str(output_dir), *args],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+def test_script_exists_and_executable():
+    assert SCRIPT.exists(), f"{SCRIPT} missing"
+
+
+class TestFaithfulSynthesis:
+    """A findings.json whose every finding maps to a real index entry must pass."""
+
+    def test_all_grounded_passes(self, tmp_path):
+        _agent_file(tmp_path, "fd-safety", ['- P0 | P0-1 | "Auth" | Token leak',
+                                            '- P1 | P1-1 | "Cache" | Stale entry'])
+        _agent_file(tmp_path, "fd-quality", ['- P2 | P2-1 | "Style" | Naming'])
+        _findings_json(tmp_path, [
+            {"id": "P0-1", "severity": "P0"},
+            {"id": "P1-1", "severity": "P1"},
+            {"id": "P2-1", "severity": "P2"},
+        ])
+        r = _run(tmp_path)
+        assert r.returncode == 0, r.stderr
+        assert "OK" in r.stdout
+
+    def test_zero_findings_is_vacuously_ok(self, tmp_path):
+        _agent_file(tmp_path, "fd-safety", [])
+        _findings_json(tmp_path, [])
+        r = _run(tmp_path)
+        assert r.returncode == 0, r.stderr
+
+
+class TestInventedFinding:
+    """A finding NOT present in any agent index ('invented coastline') must be flagged."""
+
+    def test_invented_p0_fails(self, tmp_path):
+        _agent_file(tmp_path, "fd-safety", ['- P0 | P0-1 | "Auth" | Token leak'])
+        _findings_json(tmp_path, [
+            {"id": "P0-1", "severity": "P0"},
+            {"id": "P0-99", "severity": "P0"},  # invented
+        ])
+        r = _run(tmp_path)
+        assert r.returncode == 3, f"expected violation exit 3, got {r.returncode}: {r.stdout}{r.stderr}"
+        assert "P0-99" in r.stderr
+        assert "VIOLATION" in r.stderr
+
+    def test_invented_p1_fails(self, tmp_path):
+        _agent_file(tmp_path, "fd-safety", ['- P1 | P1-1 | "Cache" | Stale entry'])
+        _findings_json(tmp_path, [{"id": "P1-7", "severity": "P1"}])  # invented
+        r = _run(tmp_path)
+        assert r.returncode == 3, r.stdout + r.stderr
+
+    def test_invented_p2_only_warns_but_passes(self, tmp_path):
+        """P2+ ungrounded is below the blocking threshold by default → warn, exit 0."""
+        _agent_file(tmp_path, "fd-quality", ['- P2 | P2-1 | "Style" | Naming'])
+        _findings_json(tmp_path, [
+            {"id": "P2-1", "severity": "P2"},
+            {"id": "P2-99", "severity": "P2"},  # invented but only P2
+        ])
+        r = _run(tmp_path)
+        assert r.returncode == 0, r.stdout + r.stderr
+        assert "warn" in r.stderr and "P2-99" in r.stderr
+
+    def test_invented_p2_fails_under_strict(self, tmp_path):
+        _agent_file(tmp_path, "fd-quality", ['- P2 | P2-1 | "Style" | Naming'])
+        _findings_json(tmp_path, [{"id": "P2-99", "severity": "P2"}])
+        r = _run(tmp_path, "--strict")
+        assert r.returncode == 3, r.stdout + r.stderr
+
+
+class TestSeverityMismatch:
+    """An id present under a different severity is a (default non-blocking) mismatch."""
+
+    def test_escalation_warns_by_default(self, tmp_path):
+        _agent_file(tmp_path, "fd-safety", ['- P1 | P1-1 | "Cache" | Stale entry'])
+        _findings_json(tmp_path, [{"id": "P1-1", "severity": "P0"}])  # escalated P1->P0
+        r = _run(tmp_path)
+        assert r.returncode == 0, r.stdout + r.stderr
+        assert "severity differs" in r.stderr
+
+    def test_escalation_fails_under_strict(self, tmp_path):
+        _agent_file(tmp_path, "fd-safety", ['- P1 | P1-1 | "Cache" | Stale entry'])
+        _findings_json(tmp_path, [{"id": "P1-1", "severity": "P0"}])
+        r = _run(tmp_path, "--strict")
+        assert r.returncode == 3, r.stdout + r.stderr
+
+
+class TestQuireMark:
+    """Foreign files (wrong/missing run-uuid) must not ground synthesized findings."""
+
+    def test_foreign_file_cannot_launder_invented_finding(self, tmp_path):
+        # Invented finding only appears in a foreign (prior-run) file.
+        _agent_file(tmp_path, "fd-safety", ['- P0 | P0-1 | "Auth" | Token leak'])
+        _agent_file(tmp_path, "fd-stale", ['- P0 | P0-99 | "X" | invented'], run_uuid="OLD-RUN")
+        _findings_json(tmp_path, [{"id": "P0-99", "severity": "P0"}])
+        r = _run(tmp_path)
+        assert r.returncode == 3, r.stdout + r.stderr
+        assert "P0-99" in r.stderr
+
+    def test_foreign_count_reported_in_json(self, tmp_path):
+        _agent_file(tmp_path, "fd-safety", ['- P0 | P0-1 | "Auth" | Token leak'])
+        _agent_file(tmp_path, "fd-stale", ['- P0 | P0-1 | "Auth" | Token leak'], run_uuid="OLD")
+        _findings_json(tmp_path, [{"id": "P0-1", "severity": "P0"}])
+        r = _run(tmp_path, "--json")
+        assert r.returncode == 0, r.stderr
+        out = json.loads(r.stdout)
+        assert out["foreign_skipped"] == 1
+        assert out["status"] == "ok"
+
+
+class TestInvocation:
+    def test_missing_findings_json_exits_2(self, tmp_path):
+        _agent_file(tmp_path, "fd-safety", ['- P0 | P0-1 | "Auth" | Token leak'])
+        r = _run(tmp_path)
+        assert r.returncode == 2
+
+    def test_missing_dir_exits_2(self, tmp_path):
+        r = _run(tmp_path / "nope")
+        assert r.returncode == 2
+
+    def test_synthesis_and_reaction_files_excluded(self, tmp_path):
+        """summary/synthesis/findings and *.reactions files are not agent indexes."""
+        _agent_file(tmp_path, "fd-safety", ['- P0 | P0-1 | "Auth" | Token leak'])
+        # A reaction file containing an index-like line must NOT ground a finding.
+        (tmp_path / "fd-safety.reactions.md").write_text(
+            f"<!-- run-uuid: {RUN} -->\n### Findings Index\n- P0 | P0-99 | \"X\" | y\n"
+        )
+        _findings_json(tmp_path, [{"id": "P0-99", "severity": "P0"}])
+        r = _run(tmp_path)
+        assert r.returncode == 3, r.stdout + r.stderr

--- a/tests/test_verify_synthesis_grounding.bats
+++ b/tests/test_verify_synthesis_grounding.bats
@@ -1,0 +1,90 @@
+#!/usr/bin/env bats
+# Tests for verify-synthesis-grounding.sh (issue #10, finding C-5):
+# structural grounding of synthesized findings against agent Findings Indexes.
+
+bats_require_minimum_version 1.5.0
+
+setup() {
+    SCRIPT="$BATS_TEST_DIRNAME/../scripts/verify-synthesis-grounding.sh"
+    TEST_DIR="$(mktemp -d)"
+    RUN="RUN-UUID-1"
+}
+
+teardown() {
+    [[ -d "$TEST_DIR" ]] && rm -rf "$TEST_DIR"
+}
+
+_agent() {
+    # _agent <name> <run-uuid> <index-line...>
+    local name="$1" uuid="$2"; shift 2
+    {
+        echo "<!-- run-uuid: ${uuid} -->"
+        echo "### Findings Index"
+        for line in "$@"; do echo "$line"; done
+        echo "Verdict: risky"
+    } > "$TEST_DIR/${name}.md"
+}
+
+@test "faithful synthesis (all findings grounded) passes" {
+    _agent fd-safety "$RUN" '- P0 | P0-1 | "Auth" | Token leak' '- P1 | P1-1 | "Cache" | Stale'
+    echo '{"findings":[{"id":"P0-1","severity":"P0"},{"id":"P1-1","severity":"P1"}]}' > "$TEST_DIR/findings.json"
+    FLUX_RUN_UUID="$RUN" run bash "$SCRIPT" "$TEST_DIR"
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"OK"* ]]
+}
+
+@test "invented P0 finding (not in any index) fails with exit 3" {
+    _agent fd-safety "$RUN" '- P0 | P0-1 | "Auth" | Token leak'
+    echo '{"findings":[{"id":"P0-1","severity":"P0"},{"id":"P0-99","severity":"P0"}]}' > "$TEST_DIR/findings.json"
+    FLUX_RUN_UUID="$RUN" run bash "$SCRIPT" "$TEST_DIR"
+    [[ "$status" -eq 3 ]]
+    [[ "$output" == *"P0-99"* ]]
+    [[ "$output" == *"VIOLATION"* ]]
+}
+
+@test "invented P2 only warns but passes (exit 0)" {
+    _agent fd-quality "$RUN" '- P2 | P2-1 | "Style" | Naming'
+    echo '{"findings":[{"id":"P2-1","severity":"P2"},{"id":"P2-99","severity":"P2"}]}' > "$TEST_DIR/findings.json"
+    FLUX_RUN_UUID="$RUN" run bash "$SCRIPT" "$TEST_DIR"
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"warn"* ]]
+}
+
+@test "--strict fails on any ungrounded finding" {
+    _agent fd-quality "$RUN" '- P2 | P2-1 | "Style" | Naming'
+    echo '{"findings":[{"id":"P2-99","severity":"P2"}]}' > "$TEST_DIR/findings.json"
+    FLUX_RUN_UUID="$RUN" run bash "$SCRIPT" "$TEST_DIR" --strict
+    [[ "$status" -eq 3 ]]
+}
+
+@test "foreign file (wrong run-uuid) cannot ground an invented finding" {
+    _agent fd-safety "$RUN" '- P0 | P0-1 | "Auth" | Token leak'
+    _agent fd-stale OLD-RUN '- P0 | P0-99 | "X" | invented'
+    echo '{"findings":[{"id":"P0-99","severity":"P0"}]}' > "$TEST_DIR/findings.json"
+    FLUX_RUN_UUID="$RUN" run bash "$SCRIPT" "$TEST_DIR"
+    [[ "$status" -eq 3 ]]
+    [[ "$output" == *"P0-99"* ]]
+}
+
+@test "severity escalation (P1 in index, P0 in synth) warns by default" {
+    _agent fd-safety "$RUN" '- P1 | P1-1 | "Cache" | Stale'
+    echo '{"findings":[{"id":"P1-1","severity":"P0"}]}' > "$TEST_DIR/findings.json"
+    FLUX_RUN_UUID="$RUN" run bash "$SCRIPT" "$TEST_DIR"
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"severity differs"* ]]
+}
+
+@test "missing findings.json exits 2" {
+    _agent fd-safety "$RUN" '- P0 | P0-1 | "Auth" | Token leak'
+    FLUX_RUN_UUID="$RUN" run bash "$SCRIPT" "$TEST_DIR"
+    [[ "$status" -eq 2 ]]
+}
+
+@test "--json emits machine-readable status" {
+    _agent fd-safety "$RUN" '- P0 | P0-1 | "Auth" | Token leak'
+    echo '{"findings":[{"id":"P0-1","severity":"P0"}]}' > "$TEST_DIR/findings.json"
+    FLUX_RUN_UUID="$RUN" run bash "$SCRIPT" "$TEST_DIR" --json
+    [[ "$status" -eq 0 ]]
+    echo "$output" | jq -e '.status == "ok"' >/dev/null
+    echo "$output" | jq -e '.checked == 1' >/dev/null
+}


### PR DESCRIPTION
Closes #10.

Adds a structural grounding check so the haiku-tier synthesizer can't surface findings that no agent actually reported.

## Mechanism
New `scripts/verify-synthesis-grounding.sh`, wired into `synthesize.md` as mandatory **Step 3.2a** (review-only). For each agent `.md` in `OUTPUT_DIR` it harvests Findings Index bullets (`^-\s*([Pp][0-9]+)\s*\|`) into a set of `SEVERITY|ID` keys, then asserts every `(severity, id)` in `findings.json` is grounded in that set.

- **Quire-mark aware (issue #6):** with `FLUX_RUN_UUID` set, files whose first line isn't `<!-- run-uuid: {uuid} -->` are Foreign and excluded — a stale file can't launder an invented finding.
- **Classification:** exact match → grounded; id present but severity differs → `severity-mismatch` (expected from "use highest" dedup); id absent → `ungrounded` (fabricated).

## Failure policy
- **Exit 3:** any ungrounded **P0/P1** (fabricated blocking verdict must fail).
- **Exit 0 (warn):** ungrounded P2+, and severity-mismatch (legit escalation).
- **`--strict`:** any ungrounded finding or mismatch fails.
- `--json` for tooling.

## Tests
- `tests/structural/test_verify_synthesis_grounding.py` (14) + `tests/test_verify_synthesis_grounding.bats` (8).
- `cd tests && uv run pytest -q` → **199 passed**.
- `bats`/`shellcheck` not in dev env; scenarios verified manually + `bash -n` clean. CI runs the bats suite.

## Note
Deliberately does not reuse `findings-helper.sh read-indexes` for extraction — its `{2,4}` interval regex isn't mawk-compatible in this env; the script matches the index bullet shape directly with mawk-safe regex while mirroring the documented grammar + exclusion set.

https://claude.ai/code/session_01VBqxaqMHtjoGXFuS1d4ui2

---
_Generated by [Claude Code](https://claude.ai/code/session_01VBqxaqMHtjoGXFuS1d4ui2)_