### PR TITLE
Close openrouter-dispatch spend-ceiling check/act window + bound model/prompt (closes #12)

### DIFF
--- a/mcp-servers/openrouter-dispatch/dispatch-core.test.ts
+++ b/mcp-servers/openrouter-dispatch/dispatch-core.test.ts
@@ -1,0 +1,283 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  DEFAULT_ESTIMATED_CALL_COST_USD,
+  DEFAULT_MAX_TOKENS_CEILING,
+  DEFAULT_MODEL_ALLOWLIST,
+  DEFAULT_PROMPT_MAX_CHARS,
+  DEFAULT_SYSTEM_PROMPT_MAX_CHARS,
+  admitAndReserve,
+  buildInputSchema,
+  loadDispatchConfig,
+  mergeCommittedMonotonic,
+  newLedger,
+  reconcile,
+  totalExposureUsd,
+} from "./dispatch-core.js";
+import { z } from "zod";
+
+// ---------------------------------------------------------------------------
+// Config parsing
+// ---------------------------------------------------------------------------
+
+test("loadDispatchConfig: defaults when env empty", () => {
+  const c = loadDispatchConfig({});
+  assert.deepEqual([...c.modelAllowlist], [...DEFAULT_MODEL_ALLOWLIST]);
+  assert.equal(c.promptMaxChars, DEFAULT_PROMPT_MAX_CHARS);
+  assert.equal(c.systemPromptMaxChars, DEFAULT_SYSTEM_PROMPT_MAX_CHARS);
+  assert.equal(c.maxTokensCeiling, DEFAULT_MAX_TOKENS_CEILING);
+  assert.equal(c.estimatedCallCostUsd, DEFAULT_ESTIMATED_CALL_COST_USD);
+});
+
+test("loadDispatchConfig: allowlist override via env", () => {
+  const c = loadDispatchConfig({
+    OPENROUTER_MODEL_ALLOWLIST: " foo/bar , baz/qux ",
+  });
+  assert.deepEqual([...c.modelAllowlist], ["foo/bar", "baz/qux"]);
+});
+
+test("loadDispatchConfig: empty allowlist env falls back to defaults", () => {
+  const c = loadDispatchConfig({ OPENROUTER_MODEL_ALLOWLIST: "  ,  " });
+  assert.deepEqual([...c.modelAllowlist], [...DEFAULT_MODEL_ALLOWLIST]);
+});
+
+test("loadDispatchConfig: numeric overrides + bad values fall back", () => {
+  const c = loadDispatchConfig({
+    OPENROUTER_PROMPT_MAX_CHARS: "1000",
+    OPENROUTER_SYSTEM_PROMPT_MAX_CHARS: "-5", // invalid -> fallback
+    OPENROUTER_MAX_TOKENS_CEILING: "abc", // invalid -> fallback
+    OPENROUTER_ESTIMATED_CALL_COST_USD: "0.25",
+  });
+  assert.equal(c.promptMaxChars, 1000);
+  assert.equal(c.systemPromptMaxChars, DEFAULT_SYSTEM_PROMPT_MAX_CHARS);
+  assert.equal(c.maxTokensCeiling, DEFAULT_MAX_TOKENS_CEILING);
+  assert.equal(c.estimatedCallCostUsd, 0.25);
+});
+
+// ---------------------------------------------------------------------------
+// Input schema: allowlist + length caps + max_tokens bound
+// ---------------------------------------------------------------------------
+
+test("schema: allowlist rejects unknown model_id", () => {
+  const c = loadDispatchConfig({});
+  const schema = z.object(buildInputSchema(c));
+  const ok = schema.safeParse({
+    model_id: "deepseek/deepseek-chat",
+    prompt: "hi",
+  });
+  assert.equal(ok.success, true);
+
+  const bad = schema.safeParse({
+    model_id: "openai/o1-pro", // expensive, not in allowlist
+    prompt: "hi",
+  });
+  assert.equal(bad.success, false);
+});
+
+test("schema: prompt length cap rejects oversized prompt", () => {
+  const c = loadDispatchConfig({ OPENROUTER_PROMPT_MAX_CHARS: "10" });
+  const schema = z.object(buildInputSchema(c));
+  const bad = schema.safeParse({
+    model_id: c.modelAllowlist[0],
+    prompt: "x".repeat(11),
+  });
+  assert.equal(bad.success, false);
+
+  const ok = schema.safeParse({
+    model_id: c.modelAllowlist[0],
+    prompt: "x".repeat(10),
+  });
+  assert.equal(ok.success, true);
+});
+
+test("schema: empty prompt rejected", () => {
+  const c = loadDispatchConfig({});
+  const schema = z.object(buildInputSchema(c));
+  const bad = schema.safeParse({ model_id: c.modelAllowlist[0], prompt: "" });
+  assert.equal(bad.success, false);
+});
+
+test("schema: system_prompt length cap rejects oversized", () => {
+  const c = loadDispatchConfig({ OPENROUTER_SYSTEM_PROMPT_MAX_CHARS: "5" });
+  const schema = z.object(buildInputSchema(c));
+  const bad = schema.safeParse({
+    model_id: c.modelAllowlist[0],
+    prompt: "hi",
+    system_prompt: "x".repeat(6),
+  });
+  assert.equal(bad.success, false);
+});
+
+test("schema: max_tokens bounded by ceiling", () => {
+  const c = loadDispatchConfig({ OPENROUTER_MAX_TOKENS_CEILING: "5000" });
+  const schema = z.object(buildInputSchema(c));
+
+  const tooBig = schema.safeParse({
+    model_id: c.modelAllowlist[0],
+    prompt: "hi",
+    max_tokens: 5001,
+  });
+  assert.equal(tooBig.success, false);
+
+  const nonInt = schema.safeParse({
+    model_id: c.modelAllowlist[0],
+    prompt: "hi",
+    max_tokens: 1.5,
+  });
+  assert.equal(nonInt.success, false);
+
+  const negative = schema.safeParse({
+    model_id: c.modelAllowlist[0],
+    prompt: "hi",
+    max_tokens: -1,
+  });
+  assert.equal(negative.success, false);
+});
+
+test("schema: max_tokens default applied when omitted", () => {
+  // Default (4096) must be within the default ceiling so omitting is always valid.
+  const c = loadDispatchConfig({});
+  const schema = z.object(buildInputSchema(c));
+  const defaulted = schema.parse({ model_id: c.modelAllowlist[0], prompt: "hi" });
+  assert.equal(defaulted.max_tokens, 4096);
+  assert.ok(4096 <= c.maxTokensCeiling);
+});
+
+// ---------------------------------------------------------------------------
+// Ledger: reservation prevents concurrent overshoot
+// ---------------------------------------------------------------------------
+
+test("reservation prevents concurrent overshoot of the ceiling", () => {
+  // Ceiling $1.00, estimate $0.50 per call. Without reservation, N concurrent
+  // calls would all pass the under-ceiling check and overshoot. With same-lock
+  // reservation, only ceil(ceiling/estimate) = 2 calls can be admitted before
+  // exposure reaches the ceiling.
+  const ledger = newLedger();
+  const ceiling = 1.0;
+  const estimate = 0.5;
+
+  const admissions: boolean[] = [];
+  for (let i = 0; i < 10; i++) {
+    const r = admitAndReserve(ledger, ceiling, estimate);
+    admissions.push(r.ok);
+  }
+
+  const admitted = admissions.filter(Boolean).length;
+  assert.equal(admitted, 2, "only 2 concurrent calls admitted");
+  // Exposure never exceeds ceiling + one in-flight estimate.
+  assert.ok(totalExposureUsd(ledger) <= ceiling + estimate);
+  // The 3rd..10th admissions were all rejected.
+  assert.deepEqual(admissions, [
+    true,
+    true,
+    false,
+    false,
+    false,
+    false,
+    false,
+    false,
+    false,
+    false,
+  ]);
+});
+
+test("reservation released and actual debited on reconcile", () => {
+  const ledger = newLedger();
+  const ceiling = 1.0;
+  const estimate = 0.5;
+
+  const r = admitAndReserve(ledger, ceiling, estimate);
+  assert.equal(r.ok, true);
+  assert.equal(ledger.reservedSpendUsd, 0.5);
+  assert.equal(ledger.committedSpendUsd, 0);
+
+  // Actual came in cheaper than the estimate.
+  reconcile(ledger, estimate, 0.1, true);
+  assert.equal(ledger.reservedSpendUsd, 0);
+  assert.equal(ledger.committedSpendUsd, 0.1);
+
+  // After reconcile, the freed budget is available again.
+  const r2 = admitAndReserve(ledger, ceiling, estimate);
+  assert.equal(r2.ok, true);
+  assert.equal(totalExposureUsd(ledger), 0.6);
+});
+
+test("ceiling disabled (<=0): no reservation, debits still tracked", () => {
+  const ledger = newLedger();
+  const r = admitAndReserve(ledger, 0, 0.5);
+  assert.equal(r.ok, true);
+  assert.equal(ledger.reservedSpendUsd, 0, "no reservation when disabled");
+  reconcile(ledger, 0.5, 0.2, false);
+  assert.equal(ledger.committedSpendUsd, 0.2);
+  assert.equal(ledger.reservedSpendUsd, 0);
+});
+
+// ---------------------------------------------------------------------------
+// Conservative debit on missing total_cost
+// ---------------------------------------------------------------------------
+
+test("missing total_cost debits conservatively (estimate), never zero", () => {
+  const ledger = newLedger();
+  const estimate = 0.5;
+  admitAndReserve(ledger, 1.0, estimate);
+
+  reconcile(ledger, estimate, undefined, true);
+  assert.equal(
+    ledger.committedSpendUsd,
+    estimate,
+    "undefined cost debits the estimate",
+  );
+  assert.equal(ledger.reservedSpendUsd, 0);
+});
+
+test("NaN / negative total_cost treated as missing -> conservative debit", () => {
+  const ledger = newLedger();
+  const estimate = 0.5;
+
+  admitAndReserve(ledger, 10, estimate);
+  reconcile(ledger, estimate, Number.NaN, true);
+  assert.equal(ledger.committedSpendUsd, estimate);
+
+  admitAndReserve(ledger, 10, estimate);
+  reconcile(ledger, estimate, -3, true);
+  assert.equal(ledger.committedSpendUsd, estimate * 2);
+});
+
+test("zero actual cost is honored (not coerced to estimate)", () => {
+  const ledger = newLedger();
+  const estimate = 0.5;
+  admitAndReserve(ledger, 1.0, estimate);
+  reconcile(ledger, estimate, 0, true);
+  // A genuine reported cost of exactly 0 is a valid debit.
+  assert.equal(ledger.committedSpendUsd, 0);
+  assert.equal(ledger.reservedSpendUsd, 0);
+});
+
+// ---------------------------------------------------------------------------
+// Ledger monotonicity
+// ---------------------------------------------------------------------------
+
+test("mergeCommittedMonotonic never decreases committed spend", () => {
+  const ledger = newLedger();
+  ledger.committedSpendUsd = 5;
+
+  // A persisted value LOWER than current must not roll the ledger back.
+  mergeCommittedMonotonic(ledger, 2);
+  assert.equal(ledger.committedSpendUsd, 5);
+
+  // A persisted value HIGHER (another instance spent more) is adopted.
+  mergeCommittedMonotonic(ledger, 9);
+  assert.equal(ledger.committedSpendUsd, 9);
+
+  // Garbage persisted value is ignored.
+  mergeCommittedMonotonic(ledger, Number.NaN);
+  assert.equal(ledger.committedSpendUsd, 9);
+});
+
+test("monotonicity defends against a same-user reset-to-zero state file", () => {
+  const ledger = newLedger();
+  ledger.committedSpendUsd = 12.34;
+  // Simulate loadState reading a tampered/rolled-back file with spend 0.
+  mergeCommittedMonotonic(ledger, 0);
+  assert.equal(ledger.committedSpendUsd, 12.34);
+});

--- a/mcp-servers/openrouter-dispatch/dispatch-core.ts
+++ b/mcp-servers/openrouter-dispatch/dispatch-core.ts
@@ -1,0 +1,237 @@
+import { z } from "zod";
+
+// ---------------------------------------------------------------------------
+// Configuration parsing
+//
+// Everything here is pure / dependency-free so it can be unit-tested without
+// starting the MCP server (which exits 78 when OPENROUTER_API_KEY is unset).
+// ---------------------------------------------------------------------------
+
+/** Default model allowlist — common, reasonably-priced OpenRouter models.
+ * Overridable via OPENROUTER_MODEL_ALLOWLIST (comma-separated). This bounds an
+ * injection-steered agent from dispatching an arbitrarily expensive model. */
+export const DEFAULT_MODEL_ALLOWLIST = [
+  "deepseek/deepseek-chat",
+  "deepseek/deepseek-r1",
+  "openai/gpt-4o-mini",
+  "openai/gpt-4o",
+  "anthropic/claude-3.5-haiku",
+  "anthropic/claude-3.5-sonnet",
+  "google/gemini-2.0-flash-001",
+  "google/gemini-flash-1.5",
+  "meta-llama/llama-3.3-70b-instruct",
+  "qwen/qwen-2.5-72b-instruct",
+] as const;
+
+/** Length caps for free-text fields. A huge prompt is both a cost vector
+ * (tokens billed scale with input length) and an injection surface. */
+export const DEFAULT_PROMPT_MAX_CHARS = 200_000;
+export const DEFAULT_SYSTEM_PROMPT_MAX_CHARS = 50_000;
+
+/** Upper bound for max_tokens on the response, independent of cost reservation. */
+export const DEFAULT_MAX_TOKENS_CEILING = 32_000;
+
+/** Conservative per-call cost estimate (USD) reserved at admission and used as
+ * the fallback debit when OpenRouter omits usage.total_cost. Overridable via
+ * OPENROUTER_ESTIMATED_CALL_COST_USD. The default is deliberately generous so
+ * concurrent admission cannot collectively overshoot the ceiling, and so an
+ * un-priced response never drifts the ledger downward to zero. */
+export const DEFAULT_ESTIMATED_CALL_COST_USD = 0.5;
+
+export type DispatchConfig = {
+  modelAllowlist: readonly string[];
+  promptMaxChars: number;
+  systemPromptMaxChars: number;
+  maxTokensCeiling: number;
+  estimatedCallCostUsd: number;
+};
+
+function parsePositiveFloat(
+  value: string | undefined,
+  fallback: number,
+): number {
+  if (value === undefined) return fallback;
+  const n = Number.parseFloat(value);
+  return Number.isFinite(n) && n > 0 ? n : fallback;
+}
+
+function parsePositiveInt(value: string | undefined, fallback: number): number {
+  if (value === undefined) return fallback;
+  const n = Number.parseInt(value, 10);
+  return Number.isFinite(n) && n > 0 ? n : fallback;
+}
+
+/** Build the dispatch config from process.env (or a provided env map for tests). */
+export function loadDispatchConfig(
+  env: NodeJS.ProcessEnv = process.env,
+): DispatchConfig {
+  const rawList = env.OPENROUTER_MODEL_ALLOWLIST;
+  const modelAllowlist = rawList
+    ? rawList
+        .split(",")
+        .map((s) => s.trim())
+        .filter((s) => s.length > 0)
+    : [...DEFAULT_MODEL_ALLOWLIST];
+
+  return {
+    modelAllowlist:
+      modelAllowlist.length > 0 ? modelAllowlist : [...DEFAULT_MODEL_ALLOWLIST],
+    promptMaxChars: parsePositiveInt(
+      env.OPENROUTER_PROMPT_MAX_CHARS,
+      DEFAULT_PROMPT_MAX_CHARS,
+    ),
+    systemPromptMaxChars: parsePositiveInt(
+      env.OPENROUTER_SYSTEM_PROMPT_MAX_CHARS,
+      DEFAULT_SYSTEM_PROMPT_MAX_CHARS,
+    ),
+    maxTokensCeiling: parsePositiveInt(
+      env.OPENROUTER_MAX_TOKENS_CEILING,
+      DEFAULT_MAX_TOKENS_CEILING,
+    ),
+    estimatedCallCostUsd: parsePositiveFloat(
+      env.OPENROUTER_ESTIMATED_CALL_COST_USD,
+      DEFAULT_ESTIMATED_CALL_COST_USD,
+    ),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Input schema
+// ---------------------------------------------------------------------------
+
+export type DispatchInput = {
+  model_id: string;
+  prompt: string;
+  system_prompt?: string;
+  max_tokens: number;
+};
+
+/** Build the zod raw-shape for the review_with_model tool, constrained by config.
+ * model_id is restricted to the allowlist; prompt/system_prompt are length-capped;
+ * max_tokens is bounded by the configured ceiling. */
+export function buildInputSchema(config: DispatchConfig) {
+  // z.enum requires a non-empty tuple of string literals. The allowlist is
+  // validated non-empty by loadDispatchConfig.
+  const allowed = config.modelAllowlist as readonly [string, ...string[]];
+
+  return {
+    model_id: z
+      .enum(allowed)
+      .describe(
+        `OpenRouter model ID. Must be one of the allowlisted models: ${config.modelAllowlist.join(", ")}`,
+      ),
+    prompt: z
+      .string()
+      .min(1)
+      .max(config.promptMaxChars)
+      .describe(`The review prompt to send (max ${config.promptMaxChars} chars)`),
+    system_prompt: z
+      .string()
+      .max(config.systemPromptMaxChars)
+      .optional()
+      .describe(
+        `System prompt for the model (max ${config.systemPromptMaxChars} chars)`,
+      ),
+    max_tokens: z
+      .number()
+      .int()
+      .positive()
+      .max(config.maxTokensCeiling)
+      .optional()
+      .default(4096)
+      .describe(`Max tokens in response (1..${config.maxTokensCeiling})`),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Spend ledger: reservation + reconciliation + monotonicity
+//
+// The ledger is split into two committed counters:
+//   - committedSpendUsd: actual debits reconciled from completed calls.
+//   - reservedSpendUsd:  estimates held for in-flight calls, not yet reconciled.
+//
+// Admission checks (committed + reserved) against the ceiling INSIDE the lock,
+// and immediately reserves the estimate in the same lock. This closes the
+// check/act window: N concurrent calls cannot all pass the under-ceiling check,
+// because each reservation is visible to the next admission.
+//
+// On completion the reservation is released and the actual cost debited. A
+// response lacking usage.total_cost is debited conservatively (the estimate),
+// never zero.
+//
+// committedSpendUsd is treated as MONOTONIC across loads: a same-user local
+// process cannot reset the persisted ledger downward.
+// ---------------------------------------------------------------------------
+
+export type Ledger = {
+  committedSpendUsd: number;
+  reservedSpendUsd: number;
+};
+
+export function newLedger(): Ledger {
+  return { committedSpendUsd: 0, reservedSpendUsd: 0 };
+}
+
+/** Total spend visible to the ceiling: committed plus outstanding reservations. */
+export function totalExposureUsd(ledger: Ledger): number {
+  return ledger.committedSpendUsd + ledger.reservedSpendUsd;
+}
+
+/** Merge a freshly-loaded persisted committed value into the in-memory ledger
+ * monotonically: never decrease committedSpendUsd. This prevents a local
+ * same-user process (or a tampered/rolled-back state file) from lowering the
+ * ledger to win more budget. Reservations are process-local and not merged. */
+export function mergeCommittedMonotonic(
+  ledger: Ledger,
+  persistedCommitted: number,
+): void {
+  if (
+    Number.isFinite(persistedCommitted) &&
+    persistedCommitted > ledger.committedSpendUsd
+  ) {
+    ledger.committedSpendUsd = persistedCommitted;
+  }
+}
+
+export type AdmitResult = { ok: true } | { ok: false; kind: "spend" };
+
+/** Attempt to admit a call against the ceiling and, on success, reserve the
+ * estimate in the same step. MUST be called inside the state lock.
+ *
+ * spendCeiling <= 0 disables the ceiling (no reservation needed).
+ * Returns ok:false without reserving when admitting would meet/exceed ceiling. */
+export function admitAndReserve(
+  ledger: Ledger,
+  spendCeiling: number,
+  estimate: number,
+): AdmitResult {
+  if (spendCeiling > 0) {
+    if (totalExposureUsd(ledger) >= spendCeiling) {
+      return { ok: false, kind: "spend" };
+    }
+    ledger.reservedSpendUsd += estimate;
+  }
+  return { ok: true };
+}
+
+/** Release a previously-held reservation and debit the actual cost.
+ * MUST be called inside the state lock, with the SAME estimate passed to
+ * admitAndReserve. `actualCost === undefined` means OpenRouter omitted the
+ * cost: debit the (conservative) estimate instead of zero. */
+export function reconcile(
+  ledger: Ledger,
+  estimate: number,
+  actualCost: number | undefined,
+  ceilingEnabled: boolean,
+): void {
+  if (ceilingEnabled) {
+    ledger.reservedSpendUsd = Math.max(0, ledger.reservedSpendUsd - estimate);
+  }
+  const debit =
+    typeof actualCost === "number" &&
+    Number.isFinite(actualCost) &&
+    actualCost >= 0
+      ? actualCost
+      : estimate;
+  ledger.committedSpendUsd += debit;
+}

--- a/mcp-servers/openrouter-dispatch/index.ts
+++ b/mcp-servers/openrouter-dispatch/index.ts
@@ -1,9 +1,17 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import { z } from "zod";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import * as os from "node:os";
+import {
+  admitAndReserve,
+  buildInputSchema,
+  loadDispatchConfig,
+  mergeCommittedMonotonic,
+  newLedger,
+  reconcile,
+  type DispatchInput,
+} from "./dispatch-core.js";
 
 const API_KEY = process.env.OPENROUTER_API_KEY;
 if (!API_KEY) {
@@ -23,6 +31,9 @@ const RATE_LIMIT = parseInt(process.env.OPENROUTER_RATE_LIMIT || "20", 10);
 const SPEND_CEILING = parseFloat(
   process.env.OPENROUTER_SPEND_CEILING_USD || "0",
 );
+const CEILING_ENABLED = SPEND_CEILING > 0;
+
+const config = loadDispatchConfig();
 
 // Rate-limit + spend state is persisted so concurrent MCP instances share one
 // budget. Without persistence each session saw the full RATE_LIMIT and
@@ -45,7 +56,11 @@ type PersistedState = {
 const refillRate = RATE_LIMIT / 60000; // tokens per ms
 let tokenBucket = RATE_LIMIT;
 let lastRefill = Date.now();
-let cumulativeSpendUsd = 0;
+
+// Spend is tracked as a committed/reserved ledger (see dispatch-core.ts). Only
+// committedSpendUsd is persisted; reservations are process-local, in-flight holds
+// that close the check/act window for concurrent calls within this process.
+const ledger = newLedger();
 
 async function acquireLock(): Promise<() => Promise<void>> {
   const deadline = Date.now() + LOCK_WAIT_MS;
@@ -96,7 +111,9 @@ async function loadState(): Promise<void> {
       tokenBucket = Math.min(RATE_LIMIT, parsed.tokenBucket);
     if (typeof parsed.lastRefill === "number") lastRefill = parsed.lastRefill;
     if (typeof parsed.cumulativeSpendUsd === "number")
-      cumulativeSpendUsd = parsed.cumulativeSpendUsd;
+      // Monotonic merge: a same-user local process (or a rolled-back state file)
+      // cannot lower the committed ledger to reclaim budget.
+      mergeCommittedMonotonic(ledger, parsed.cumulativeSpendUsd);
   } catch (err: unknown) {
     const code = (err as NodeJS.ErrnoException | undefined)?.code;
     if (code !== "ENOENT") {
@@ -113,7 +130,10 @@ async function saveState(): Promise<void> {
   const payload: PersistedState = {
     tokenBucket,
     lastRefill,
-    cumulativeSpendUsd,
+    // Persist only committed spend. Outstanding reservations are process-local
+    // and would be double-counted if shared; they reconcile to committed on
+    // call completion.
+    cumulativeSpendUsd: ledger.committedSpendUsd,
     updatedAt: new Date().toISOString(),
   };
   const tmp = `${STATE_FILE}.tmp.${process.pid}`;
@@ -157,27 +177,23 @@ const server = new McpServer({
 server.tool(
   "review_with_model",
   "Dispatch a review prompt to a model via OpenRouter",
-  {
-    model_id: z
-      .string()
-      .describe("OpenRouter model ID (e.g., 'deepseek/deepseek-chat')"),
-    prompt: z.string().describe("The review prompt to send"),
-    system_prompt: z
-      .string()
-      .optional()
-      .describe("System prompt for the model"),
-    max_tokens: z
-      .number()
-      .optional()
-      .default(4096)
-      .describe("Max tokens in response"),
-  },
-  async ({ model_id, prompt, system_prompt, max_tokens }) => {
+  buildInputSchema(config),
+  async ({ model_id, prompt, system_prompt, max_tokens }: DispatchInput) => {
+    // Admission, rate token, AND cost reservation all happen inside ONE lock.
+    // Reserving the estimate here (not after the network call) closes the
+    // check/act window: concurrent admissions each see prior reservations, so
+    // they cannot collectively overshoot the ceiling by in-flight concurrency.
+    const estimate = config.estimatedCallCostUsd;
     const acquired = await withStateLock(() => {
-      if (SPEND_CEILING > 0 && cumulativeSpendUsd >= SPEND_CEILING) {
+      const admit = admitAndReserve(ledger, SPEND_CEILING, estimate);
+      if (!admit.ok) {
         return { ok: false as const, kind: "spend" as const };
       }
       if (!tryAcquireInMemory()) {
+        // Roll back the reservation we just took — the call won't proceed.
+        // Debiting 0 actual releases the held reservation and leaves committed
+        // spend unchanged, so a rate-limited call costs no budget.
+        reconcile(ledger, estimate, 0, CEILING_ENABLED);
         return { ok: false as const, kind: "rate" as const };
       }
       return { ok: true as const };
@@ -205,7 +221,7 @@ server.tool(
             type: "text" as const,
             text: JSON.stringify({
               error: "spend_ceiling_exceeded",
-              message: `Cumulative spend $${cumulativeSpendUsd.toFixed(4)} >= ceiling $${SPEND_CEILING}`,
+              message: `Cumulative spend $${ledger.committedSpendUsd.toFixed(4)} (+ reserved) >= ceiling $${SPEND_CEILING}`,
             }),
           },
         ],
@@ -213,73 +229,93 @@ server.tool(
       };
     }
 
-    const startMs = Date.now();
-    const messages: Array<{ role: string; content: string }> = [];
-    if (system_prompt)
-      messages.push({ role: "system", content: system_prompt });
-    messages.push({ role: "user", content: prompt });
+    // From here the reservation is held; it MUST be reconciled on every exit
+    // path below so a thrown error or HTTP failure never leaks a reservation.
+    let actualCost: number | undefined;
+    try {
+      const startMs = Date.now();
+      const messages: Array<{ role: string; content: string }> = [];
+      if (system_prompt)
+        messages.push({ role: "system", content: system_prompt });
+      messages.push({ role: "user", content: prompt });
 
-    const resp = await fetch("https://openrouter.ai/api/v1/chat/completions", {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${API_KEY}`,
-        "Content-Type": "application/json",
-        "HTTP-Referer": "https://github.com/sylveste-ai/sylveste",
-        "X-Title": "FluxBench Qualification",
-      },
-      body: JSON.stringify({ model: model_id, messages, max_tokens }),
-    });
+      const resp = await fetch(
+        "https://openrouter.ai/api/v1/chat/completions",
+        {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${API_KEY}`,
+            "Content-Type": "application/json",
+            "HTTP-Referer": "https://github.com/sylveste-ai/sylveste",
+            "X-Title": "FluxBench Qualification",
+          },
+          body: JSON.stringify({ model: model_id, messages, max_tokens }),
+        },
+      );
 
-    const latencyMs = Date.now() - startMs;
+      const latencyMs = Date.now() - startMs;
 
-    if (!resp.ok) {
-      const body = await resp.text();
+      if (!resp.ok) {
+        // The request reached OpenRouter and may have been (partially) billed;
+        // leave actualCost undefined so reconcile debits the conservative
+        // estimate rather than zero.
+        const body = await resp.text();
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify({
+                error: `openrouter_${resp.status}`,
+                message: body.slice(0, 500),
+                latency_ms: latencyMs,
+              }),
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      const data = (await resp.json()) as {
+        choices: Array<{ message: { content: string } }>;
+        usage?: {
+          prompt_tokens: number;
+          completion_tokens: number;
+          total_cost?: number;
+        };
+        model: string;
+      };
+
+      const tokensUsed =
+        (data.usage?.prompt_tokens ?? 0) +
+        (data.usage?.completion_tokens ?? 0);
+      // A response WITHOUT a usable total_cost is still billed — leave
+      // actualCost undefined so reconcile() debits the conservative estimate,
+      // never zero (which would drift the ceiling upward over time).
+      const rawCost = data.usage?.total_cost;
+      if (typeof rawCost === "number" && Number.isFinite(rawCost) && rawCost >= 0) {
+        actualCost = rawCost;
+      }
+
       return {
         content: [
           {
             type: "text" as const,
             text: JSON.stringify({
-              error: `openrouter_${resp.status}`,
-              message: body.slice(0, 500),
+              content: data.choices[0]?.message?.content ?? "",
+              model: data.model,
+              tokens_used: tokensUsed,
               latency_ms: latencyMs,
             }),
           },
         ],
-        isError: true,
       };
-    }
-
-    const data = (await resp.json()) as {
-      choices: Array<{ message: { content: string } }>;
-      usage?: {
-        prompt_tokens: number;
-        completion_tokens: number;
-        total_cost?: number;
-      };
-      model: string;
-    };
-
-    const tokensUsed =
-      (data.usage?.prompt_tokens ?? 0) + (data.usage?.completion_tokens ?? 0);
-    if (data.usage?.total_cost) {
+    } finally {
+      // Always release the reservation and debit the actual (or conservative)
+      // cost, regardless of how the call exited.
       await withStateLock(() => {
-        cumulativeSpendUsd += data.usage!.total_cost!;
+        reconcile(ledger, estimate, actualCost, CEILING_ENABLED);
       });
     }
-
-    return {
-      content: [
-        {
-          type: "text" as const,
-          text: JSON.stringify({
-            content: data.choices[0]?.message?.content ?? "",
-            model: data.model,
-            tokens_used: tokensUsed,
-            latency_ms: latencyMs,
-          }),
-        },
-      ],
-    };
   },
 );
 

--- a/mcp-servers/openrouter-dispatch/package-lock.json
+++ b/mcp-servers/openrouter-dispatch/package-lock.json
@@ -13,7 +13,450 @@
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
+        "tsx": "^4.22.4",
         "typescript": "^5.5.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@hono/node-server": {
@@ -342,6 +785,48 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
     "node_modules/escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
@@ -498,6 +983,21 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/function-bind": {
@@ -1076,6 +1576,25 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.4.tgz",
+      "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
       }
     },
     "node_modules/type-is": {

--- a/mcp-servers/openrouter-dispatch/package.json
+++ b/mcp-servers/openrouter-dispatch/package.json
@@ -6,14 +6,16 @@
   "main": "dist/index.js",
   "scripts": {
     "build": "tsc",
-    "start": "node dist/index.js"
+    "start": "node dist/index.js",
+    "test": "node --import tsx --test dispatch-core.test.ts"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",
     "zod": "^3.22.0"
   },
   "devDependencies": {
-    "typescript": "^5.5.0",
-    "@types/node": "^22.0.0"
+    "@types/node": "^22.0.0",
+    "tsx": "^4.22.4",
+    "typescript": "^5.5.0"
   }
 }

--- a/mcp-servers/openrouter-dispatch/tsconfig.json
+++ b/mcp-servers/openrouter-dispatch/tsconfig.json
@@ -11,6 +11,12 @@
     "declaration": true
   },
   "include": [
-    "index.ts"
+    "index.ts",
+    "dispatch-core.ts"
+  ],
+  "exclude": [
+    "dispatch-core.test.ts",
+    "dist",
+    "node_modules"
   ]
 }


### PR DESCRIPTION
Closes #12.

Closes the spend-ceiling check/act window and bounds the dispatch surface in `openrouter-dispatch`.

## Changes
- **`dispatch-core.ts`** (new): pure, dependency-free module (config parsing, zod schema builder, ledger math) so the logic is unit-testable without booting the server (which `process.exit(78)`s without `OPENROUTER_API_KEY`).
- **`index.ts`**: rewired `review_with_model` to use the core module.
- **`dispatch-core.test.ts`** (new): 18 `node:test` cases.
- `tsconfig.json` / `package.json` / `package-lock.json`: include core, exclude test from `dist/`, add `test` script + `tsx` devDep.

## How each fix works
- **Reservation/reconcile (check/act window):** `admitAndReserve()` runs inside the **same** `withStateLock` as the ceiling check + rate token — checks `committed + reserved >= ceiling` and adds the per-call estimate to `reserved` on admit, so concurrent admissions see each other and can't collectively overshoot. A `finally` calls `reconcile()` to release the reservation and debit actual. Test: 10 concurrent admissions, $1 ceiling / $0.50 estimate → exactly 2 admitted.
- **Allowlist:** `model_id` is `z.enum(allowlist)` (10 sensible defaults, overridable via `OPENROUTER_MODEL_ALLOWLIST`).
- **Caps:** `prompt` (200k), `system_prompt` (50k), `max_tokens` (≤32k, positive int) — env-overridable.
- **Conservative debit:** missing/NaN/negative `total_cost` debits the estimate, not zero (genuine `0` honored).
- **Monotonic ledger:** `loadState` routes persisted value through `mergeCommittedMonotonic()` — never lowers committed spend, so a local rollback can't reclaim budget.

## Tests / build
- `npm run build` clean; `dist/` ships only `index.*` + `dispatch-core.*`.
- `npm test` → **18 pass, 0 fail.**
- `cd tests && uv run pytest -q` → **185 passed** (structural suite unaffected).

https://claude.ai/code/session_01VBqxaqMHtjoGXFuS1d4ui2

---
_Generated by [Claude Code](https://claude.ai/code/session_01VBqxaqMHtjoGXFuS1d4ui2)_