### PR TITLE
Add 429/rate-limit backpressure to dispatch (closes #9)

### DIFF
--- a/config/flux-drive/budget.yaml
+++ b/config/flux-drive/budget.yaml
@@ -41,6 +41,20 @@ dispatch:
                              # (typically 2-3 agents) unconstrained. Raise on higher-tier
                              # keys; lower (3-4) on rate-limited keys / many heavy agents.
 
+  # Transient-failure backpressure (issue #9) — TCP/client-go congestion control.
+  # Enforced by scripts/flux-backoff.sh: a 429/rate-limit/overloaded failure is
+  # classified TRANSIENT (not counted as failed), then the agent is re-enqueued
+  # with exponential backoff + full jitter while the EFFECTIVE concurrency cap is
+  # multiplicatively decreased for the rest of the run (cap /= decrease_factor,
+  # floored at min_effective_cap). The reduced cap is written to
+  # {OUTPUT_DIR}/.dispatch-cap and honored by flux-dispatch.sh acquire.
+  backoff:
+    base_delay_secs: 2       # attempt-1 exponential window (seconds)
+    max_delay_secs: 60       # ceiling on the exponential window
+    factor: 2                # exponential multiplier per attempt
+    decrease_factor: 2       # multiplicative decrease divisor on sustained 429
+    min_effective_cap: 1     # never throttle below this many in-flight (progress)
+
 # Budget enforcement
 enforcement: soft          # soft = warn + offer override | hard = block
 cost_basis: billing        # billing = input+output (cache reads free) | total = all tokens incl. cache

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -29,9 +29,11 @@ When multiple scripts share a process and all use `flock(2)` (per-FD locks), fd 
 | 201 | Model registry | `${MODEL_REGISTRY}.lock` | `lib-registry.sh`, `fluxbench-drift.sh`, `fluxbench-qualify.sh`, `discover-merge.sh` |
 | 202 | Sync state | `*.sync.lock` | `fluxbench-sync.sh` |
 | 203 | Peer findings JSONL | `${findings_file}.lock` | `findings-helper.sh` |
-| 204 | Dispatch slots (concurrency cap) | `{OUTPUT_DIR}/.dispatch-slots.lock` | `flux-dispatch.sh` |
+| 204 | Dispatch slots + congestion cap (concurrency) | `{OUTPUT_DIR}/.dispatch-slots.lock` | `flux-dispatch.sh`, `flux-backoff.sh` |
 
 **Rule:** never reuse an fd across lock domains in the same process. When adding a new lock domain, pick the next free fd and update this table.
+
+`flux-backoff.sh` (issue #9 transient-failure backpressure) deliberately **shares** fd 204 rather than taking its own: it mutates `{OUTPUT_DIR}/.dispatch-cap` (the congestion cap read by `flux-dispatch.sh acquire`) under the *same* `.dispatch-slots.lock`, so cap writes and slot reads serialize against one lock domain. A 429 classified `transient` triggers `decrease` (cap /= 2, floored at `min_effective_cap`); `acquire` then admits against `min(base_max, .dispatch-cap)`. See `skills/flux-engine/phases/shared-contracts.md` § Transient-Failure Backpressure.
 
 ## Atomic registry mutations
 

--- a/scripts/flux-backoff.sh
+++ b/scripts/flux-backoff.sh
@@ -1,0 +1,282 @@
+#!/usr/bin/env bash
+# flux-backoff.sh — transient-failure backpressure for agent dispatch (issue #9).
+#
+# Problem (finding C-2): launch.md cites ~30% retry-token waste at 16-agent
+# fan-out, yet dispatch had no 429/backoff handling. The only retry was the
+# synchronous partial-completion Retry Race Protocol, which retries at the SAME
+# concurrency with NO backoff and cannot tell "rate-limited / never started"
+# from "crashed" from "slow". A plain 429 leaves no .md/.partial and stays
+# invisible until the 300s flux-watch timeout.
+#
+# This script adds a distinct TRANSIENT-FAILURE class with TCP/client-go style
+# congestion control that composes with flux-dispatch.sh's flock slot semaphore:
+#
+#   * classify  — recognize 429 / rate-limit / overloaded as TRANSIENT, separate
+#                 from terminal (Usage-Policy refusal) and unknown (crash/stall).
+#   * delay     — exponential backoff + full jitter for a given attempt number,
+#                 bounded by a cap. Prints the chosen delay (does not sleep).
+#   * sleep     — compute the delay AND sleep it (delay + sleep in one call).
+#   * decrease  — multiplicatively decrease the EFFECTIVE concurrency cap for the
+#                 rest of the run (writes {OUTPUT_DIR}/.dispatch-cap). On sustained
+#                 429 the cap halves each time, floored at MIN_EFFECTIVE_CAP.
+#   * increase  — additive recovery (slow-start style) after a clean window.
+#   * effective — print the current effective cap (min of base cap and the
+#                 congestion-reduced cap). flux-dispatch.sh acquire reads this so
+#                 the reduced cap actually throttles subsequent dispatches.
+#   * reset     — clear the congestion cap back to the base.
+#
+# The effective-cap file is the shared state that lets backpressure compose with
+# the existing semaphore: flux-dispatch.sh resolves max as
+#   min(base_max, .dispatch-cap)  (see flux-dispatch.sh resolve_max).
+# So a `decrease` here lowers the slot ceiling for every later `acquire`.
+#
+# Why BEFORE the 300s timeout: a 429 produces no .partial, so the stall/timeout
+# path only notices it after the full window. The orchestrator must classify the
+# subagent transcript as TRANSIENT the moment the Agent tool returns, then
+# `decrease` + `sleep` + re-enqueue — engaging backpressure immediately.
+#
+# fd: this script does NOT take a flock fd of its own. The cap file is mutated
+# under flux-dispatch.sh's existing fd-204 dispatch-slots lock so cap reads in
+# `acquire` and cap writes here serialize against the same lock domain.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BUDGET_CONFIG="${BUDGET_CONFIG:-${SCRIPT_DIR}/../config/flux-drive/budget.yaml}"
+
+# --- Tunables (env > budget.yaml > default) -------------------------------
+# Backoff base/cap are in seconds. Jitter is "full jitter": the actual delay is
+# a uniform random pick in [0, exp_delay], which decorrelates retries across the
+# fan-out so a synchronized thundering-herd retry doesn't re-trigger the limit.
+DEFAULT_BASE_DELAY=2        # seconds; attempt 1 caps exp window at base*2^0 = 2
+DEFAULT_MAX_DELAY=60        # seconds; ceiling on the exponential window
+DEFAULT_BACKOFF_FACTOR=2    # exponential multiplier
+DEFAULT_DECREASE_FACTOR=2   # multiplicative DEcrease divisor (cap /= 2 per 429)
+DEFAULT_MIN_EFFECTIVE_CAP=1 # never throttle below 1 in-flight (forward progress)
+
+_budget_get() {
+    # $1 = dotted key under `backoff:` in budget.yaml; echoes value or nothing.
+    [[ -f "$BUDGET_CONFIG" ]] || return 0
+    python3 - "$BUDGET_CONFIG" "$1" <<'PY' 2>/dev/null || true
+import sys
+try:
+    import yaml
+except Exception:
+    sys.exit(0)
+try:
+    with open(sys.argv[1]) as fh:
+        data = yaml.safe_load(fh) or {}
+except Exception:
+    sys.exit(0)
+node = (data.get("dispatch") or {}).get("backoff") or {}
+val = node.get(sys.argv[2])
+if isinstance(val, (int, float)) and val > 0:
+    print(int(val) if float(val).is_integer() else val)
+PY
+}
+
+_num() {
+    # Resolve a numeric tunable: env override $1 → budget key $2 → default $3.
+    local env_val="$1" budget_key="$2" default="$3" b
+    if [[ -n "$env_val" && "$env_val" =~ ^[0-9]+$ && "$env_val" -gt 0 ]]; then
+        echo "$env_val"; return 0
+    fi
+    b="$(_budget_get "$budget_key")"
+    if [[ -n "$b" && "$b" =~ ^[0-9]+$ && "$b" -gt 0 ]]; then
+        echo "$b"; return 0
+    fi
+    echo "$default"
+}
+
+BASE_DELAY="$(_num "${FLUX_BACKOFF_BASE_DELAY:-}" base_delay_secs "$DEFAULT_BASE_DELAY")"
+MAX_DELAY="$(_num "${FLUX_BACKOFF_MAX_DELAY:-}" max_delay_secs "$DEFAULT_MAX_DELAY")"
+BACKOFF_FACTOR="$(_num "${FLUX_BACKOFF_FACTOR:-}" factor "$DEFAULT_BACKOFF_FACTOR")"
+DECREASE_FACTOR="$(_num "${FLUX_BACKOFF_DECREASE_FACTOR:-}" decrease_factor "$DEFAULT_DECREASE_FACTOR")"
+MIN_EFFECTIVE_CAP="$(_num "${FLUX_BACKOFF_MIN_CAP:-}" min_effective_cap "$DEFAULT_MIN_EFFECTIVE_CAP")"
+
+_cap_file()  { echo "${1%/}/.dispatch-cap"; }
+_lock_file() { echo "${1%/}/.dispatch-slots.lock"; }  # shared fd-204 domain
+
+# Read the congestion cap (the throttled ceiling). Empty/garbage = unset.
+_read_cap() {
+    local f="$1" v
+    v="$(cat "$f" 2>/dev/null || true)"
+    [[ "$v" =~ ^[0-9]+$ ]] && echo "$v" || echo ""
+}
+
+# --- classify: TRANSIENT vs TERMINAL vs UNKNOWN ---------------------------
+# Reads candidate failure text from $1 (a file path) or, if $1 is "-" / absent,
+# from stdin. Prints exactly one of: transient | terminal | unknown. Exit 0.
+#
+# TRANSIENT  — rate limited / overloaded / never started. Do NOT count as failed;
+#              back off + re-enqueue + decrease concurrency.
+# TERMINAL   — deterministic refusal (Usage Policy). Same input will refuse again;
+#              caller must tier-downgrade, not plain-retry (handled in launch.md).
+# UNKNOWN    — crash / silent stall / anything unrecognized. Falls through to the
+#              existing Retry Race / stall-rescue path (no concurrency decrease).
+classify() {
+    local src="${1:--}" text
+    if [[ "$src" == "-" ]]; then
+        text="$(cat)"
+    elif [[ -f "$src" ]]; then
+        text="$(cat "$src")"
+    else
+        text="$src"   # treat a non-file argument as the literal text
+    fi
+
+    # Terminal first: the deterministic Usage-Policy refusal is NOT transient even
+    # though it is a kind of API error. Anchor loosely (it can appear mid-line in a
+    # transcript) but require the distinctive phrase.
+    if grep -qiE 'unable to respond to this request.*violate (our|the) usage policy' <<<"$text"; then
+        echo terminal; return 0
+    fi
+
+    # Transient: HTTP 429, named rate-limit / overloaded errors, quota/capacity.
+    # Anthropic surfaces these as "429", "rate_limit_error", "overloaded_error",
+    # "Overloaded", "Too Many Requests", "rate limit", "rate-limited".
+    if grep -qiE '(^|[^0-9])429([^0-9]|$)|rate[ _-]?limit|overloaded|too many requests|quota exceeded|capacity|temporarily unavailable|service unavailable|(^|[^0-9])(502|503|529)([^0-9]|$)' <<<"$text"; then
+        echo transient; return 0
+    fi
+
+    echo unknown
+}
+
+# --- delay: exponential backoff + full jitter (compute only) --------------
+# Usage: delay <attempt>   (attempt is 1-based)
+# exp_window = min(MAX_DELAY, BASE_DELAY * FACTOR^(attempt-1))
+# delay      = uniform random in [0, exp_window]   (full jitter, AWS-style)
+delay() {
+    local attempt="${1:?delay requires <attempt>}"
+    [[ "$attempt" =~ ^[0-9]+$ && "$attempt" -ge 1 ]] || attempt=1
+    local window="$BASE_DELAY" i
+    for (( i=1; i<attempt; i++ )); do
+        window=$(( window * BACKOFF_FACTOR ))
+        if (( window >= MAX_DELAY )); then window="$MAX_DELAY"; break; fi
+    done
+    (( window > MAX_DELAY )) && window="$MAX_DELAY"
+    # Full jitter: pick uniformly in [0, window]. RANDOM is 0..32767.
+    local d=$(( (RANDOM * (window + 1)) / 32768 ))
+    (( d > window )) && d="$window"
+    echo "$d"
+}
+
+# --- sleep: compute delay AND sleep it ------------------------------------
+sleep_backoff() {
+    local attempt="${1:?sleep requires <attempt>}"
+    local d
+    d="$(delay "$attempt")"
+    sleep "$d"
+    echo "$d"
+}
+
+# --- decrease: multiplicative concurrency decrease (congestion control) ----
+# Usage: decrease <output_dir> [base_max]
+# Halves the current effective cap (cap = ceil(cap / DECREASE_FACTOR)),
+# floored at MIN_EFFECTIVE_CAP. If no cap is set yet, seeds from base_max
+# (resolved via flux-dispatch.sh if absent) before halving. Mutates under the
+# shared fd-204 dispatch lock so it is consistent with concurrent `acquire`s.
+decrease() {
+    local output_dir="${1:?decrease requires <output_dir>}"; shift || true
+    local base_max="${1:-}"
+    mkdir -p "$output_dir"
+    local cap_file lock
+    cap_file="$(_cap_file "$output_dir")"; lock="$(_lock_file "$output_dir")"
+
+    if [[ -z "$base_max" ]]; then
+        base_max="$(bash "$SCRIPT_DIR/flux-dispatch.sh" maxcap "$output_dir" 2>/dev/null || echo 6)"
+    fi
+
+    local new cur
+    # Hold the shared dispatch lock for the read-modify-write. Open fd 204 on the
+    # lock for this whole function (subshell-with-redirect can't return a value via
+    # $()), then flock it.
+    exec 204>"$lock"
+    flock -x 204
+    cur="$(_read_cap "$cap_file")"
+    [[ -z "$cur" ]] && cur="$base_max"
+    # ceil division so an odd cap doesn't collapse a step early
+    new=$(( (cur + DECREASE_FACTOR - 1) / DECREASE_FACTOR ))
+    (( new < MIN_EFFECTIVE_CAP )) && new="$MIN_EFFECTIVE_CAP"
+    echo "$new" > "$cap_file"
+    flock -u 204
+    exec 204>&-
+    echo "$new"
+}
+
+# --- increase: additive recovery (slow-start) ------------------------------
+# Usage: increase <output_dir> [base_max]
+# Adds 1 to the effective cap after a clean window, never above base_max.
+# Clears the cap file once it reaches base_max so resolution returns to normal.
+increase() {
+    local output_dir="${1:?increase requires <output_dir>}"; shift || true
+    local base_max="${1:-}"
+    mkdir -p "$output_dir"
+    local cap_file lock
+    cap_file="$(_cap_file "$output_dir")"; lock="$(_lock_file "$output_dir")"
+
+    if [[ -z "$base_max" ]]; then
+        base_max="$(bash "$SCRIPT_DIR/flux-dispatch.sh" maxcap "$output_dir" 2>/dev/null || echo 6)"
+    fi
+
+    local out cur n
+    exec 204>"$lock"
+    flock -x 204
+    cur="$(_read_cap "$cap_file")"
+    if [[ -z "$cur" ]]; then
+        out="$base_max"   # already at base; nothing throttled
+    else
+        n=$(( cur + 1 ))
+        if (( n >= base_max )); then
+            rm -f "$cap_file"   # fully recovered — resolution falls back to base
+            out="$base_max"
+        else
+            echo "$n" > "$cap_file"
+            out="$n"
+        fi
+    fi
+    flock -u 204
+    exec 204>&-
+    echo "$out"
+}
+
+# --- effective: print the current effective cap ---------------------------
+# Usage: effective <output_dir> [base_max]
+# Returns min(base_max, congestion_cap). flux-dispatch.sh calls this from
+# resolve_max so a decreased cap throttles subsequent acquires.
+effective() {
+    local output_dir="${1:?effective requires <output_dir>}"; shift || true
+    local base_max="${1:-6}"
+    local cap_file cur
+    cap_file="$(_cap_file "$output_dir")"
+    cur="$(_read_cap "$cap_file")"
+    if [[ -z "$cur" ]]; then
+        echo "$base_max"; return 0
+    fi
+    if (( cur < base_max )); then echo "$cur"; else echo "$base_max"; fi
+}
+
+# --- reset: clear congestion cap back to base -----------------------------
+reset() {
+    local output_dir="${1:?reset requires <output_dir>}"
+    local cap_file
+    cap_file="$(_cap_file "$output_dir")"
+    rm -f "$cap_file"
+    echo "ok"
+}
+
+cmd="${1:?Usage: flux-backoff.sh <classify|delay|sleep|decrease|increase|effective|reset> ...}"
+shift || true
+
+case "$cmd" in
+  classify) classify "${1:--}" ;;
+  delay)    delay "${1:?delay requires <attempt>}" ;;
+  sleep)    sleep_backoff "${1:?sleep requires <attempt>}" ;;
+  decrease) decrease "$@" ;;
+  increase) increase "$@" ;;
+  effective) effective "$@" ;;
+  reset)    reset "${1:?reset requires <output_dir>}" ;;
+  *)
+    echo "flux-backoff.sh: unknown command '$cmd'" >&2
+    echo "Usage: flux-backoff.sh <classify|delay|sleep|decrease|increase|effective|reset> ..." >&2
+    exit 2
+    ;;
+esac

--- a/scripts/flux-dispatch.sh
+++ b/scripts/flux-dispatch.sh
@@ -20,7 +20,16 @@
 #       terminal .md) appears, then release one slot. Exit 0 on appearance,
 #       1 on timeout (slot is still released so the cap cannot deadlock).
 #   flux-dispatch.sh reset <output_dir> [max]
-#       (Re)initialize the slot file to zero in-flight. Call once before a wave.
+#       (Re)initialize the slot file to zero in-flight and clear any congestion
+#       cap from a prior run. Call once before a wave.
+#   flux-dispatch.sh maxcap <output_dir> [max]
+#       Print the resolved BASE cap (ignoring the congestion cap). Used by
+#       scripts/flux-backoff.sh to seed the multiplicative-decrease cap.
+#
+# Backpressure (issue #9): scripts/flux-backoff.sh writes a congestion cap to
+# {OUTPUT_DIR}/.dispatch-cap on sustained 429s. `acquire` claims against the
+# EFFECTIVE cap = min(base_max, .dispatch-cap), so transient-failure backpressure
+# multiplicatively lowers the live slot ceiling. See flux-backoff.sh.
 #
 # Resolution order for <max> (highest precedence first):
 #   1. explicit <max> argument
@@ -79,6 +88,22 @@ resolve_max() {
 
 _slot_file() { echo "${1%/}/.dispatch-slots"; }
 _lock_file() { echo "${1%/}/.dispatch-slots.lock"; }
+_cap_file()  { echo "${1%/}/.dispatch-cap"; }   # congestion cap (issue #9 backpressure)
+
+# Effective cap = min(base_max, congestion_cap). The congestion cap is written by
+# flux-backoff.sh `decrease` on sustained 429s (issue #9), so a transient-failure
+# backpressure event lowers the slot ceiling for every subsequent acquire. When no
+# congestion cap is set, the effective cap equals the base resolved cap.
+effective_max() {
+    local output_dir="$1" base="$2" cap_file cur
+    cap_file="$(_cap_file "$output_dir")"
+    cur="$(cat "$cap_file" 2>/dev/null || true)"
+    if [[ "$cur" =~ ^[0-9]+$ ]] && (( cur > 0 )) && (( cur < base )); then
+        echo "$cur"
+    else
+        echo "$base"
+    fi
+}
 
 # Read the current count (0 if file missing/empty/garbage).
 _read_count() {
@@ -94,10 +119,11 @@ case "$cmd" in
   reset)
     output_dir="${1:?reset requires <output_dir>}"; shift || true
     mkdir -p "$output_dir"
-    slot="$(_slot_file "$output_dir")"; lock="$(_lock_file "$output_dir")"
+    slot="$(_slot_file "$output_dir")"; lock="$(_lock_file "$output_dir")"; cap="$(_cap_file "$output_dir")"
     (
       flock -x 204
       echo 0 > "$slot"
+      rm -f "$cap"   # clear any congestion cap left by a prior run (issue #9)
     ) 204>"$lock"
     echo "ok 0/$(resolve_max "${1:-}")"
     ;;
@@ -114,33 +140,45 @@ case "$cmd" in
 
   acquire)
     output_dir="${1:?acquire requires <output_dir>}"; shift || true
-    max="$(resolve_max "${1:-}")"; shift || true
+    base_max="$(resolve_max "${1:-}")"; shift || true
     timeout="${1:-$DEFAULT_TIMEOUT}"
     mkdir -p "$output_dir"
     slot="$(_slot_file "$output_dir")"; lock="$(_lock_file "$output_dir")"
     deadline=$(( $(date +%s) + timeout ))
     while :; do
         claimed=""
-        # Critical section: read count, claim a slot if one is free.
+        eff=""
+        # Critical section: re-read the effective (congestion-adjusted) cap and
+        # claim a slot if one is free. Re-reading inside the loop means a mid-run
+        # flux-backoff.sh `decrease` (issue #9) throttles pending acquires too.
         (
           flock -x 204
+          eff_local="$(effective_max "$output_dir" "$base_max")"
           cur="$(_read_count "$slot")"
-          if (( cur < max )); then
+          if (( cur < eff_local )); then
               echo $(( cur + 1 )) > "$slot"
               exit 0   # signal "claimed" to parent via subshell exit
           fi
           exit 10      # signal "full"
         ) 204>"$lock" && claimed=1 || claimed=""
+        eff="$(effective_max "$output_dir" "$base_max")"
         if [[ -n "$claimed" ]]; then
-            echo "ok $(_read_count "$slot")/$max"
+            echo "ok $(_read_count "$slot")/$eff"
             exit 0
         fi
         if (( $(date +%s) >= deadline )); then
-            echo "timeout $(_read_count "$slot")/$max" >&2
+            echo "timeout $(_read_count "$slot")/$eff" >&2
             exit 1
         fi
         sleep "$POLL_INTERVAL"
     done
+    ;;
+
+  maxcap)
+    # Print the resolved BASE cap (ignores the congestion cap). flux-backoff.sh
+    # `decrease`/`increase` call this to seed the congestion cap from the base.
+    output_dir="${1:?maxcap requires <output_dir>}"; shift || true
+    resolve_max "${1:-}"
     ;;
 
   release)

--- a/skills/flux-engine/phases/launch.md
+++ b/skills/flux-engine/phases/launch.md
@@ -184,6 +184,8 @@ After each stage launch, tell the user:
 
 Anthropic API rate limits and prompt-cache contention degrade throughput when too many agents fan out simultaneously (Erlang C predicts ~30% retry-token waste at the 16-agent fan-out tier). The concurrency cap is **mechanically enforced** by `scripts/flux-dispatch.sh` — a `flock`-guarded slot semaphore at `{OUTPUT_DIR}/.dispatch-slots` that holds at most `MAX_CONCURRENT_AGENTS` tokens. This is admission control, not advice: a dispatch path that fails to acquire a slot blocks until one frees, so the orchestrator cannot breach the cap by emitting all `Agent` calls at once.
 
+The cap is not static: it is **congestion-controlled**. When agents hit rate limits (HTTP 429 / `overloaded_error`), `scripts/flux-backoff.sh decrease` multiplicatively lowers the *effective* cap for the rest of the run (TCP/client-go style), and `acquire` claims against `min(MAX_CONCURRENT_AGENTS, congestion_cap)`. See **Transient-failure backpressure** below — this is the enforced response to 429s the Erlang-C waste figure is about.
+
 ```
 MAX_CONCURRENT_AGENTS = ${MAX_CONCURRENT_AGENTS:-6}
 ```
@@ -216,6 +218,44 @@ The slot file is the single chokepoint: every fan-out path must `acquire` before
 **Why 6:** at the default Anthropic API tier, 6 concurrent agents stays inside the per-minute concurrent-session limit while keeping Stage 1 (typically 2-3 agents) unconstrained. Tune via env when running on higher-tier API keys or when the workload is many small/cheap agents.
 
 **Override** for genuinely concurrent-tolerant runs (large API quotas, fast agents, or where total wall-clock matters more than retry waste): set `MAX_CONCURRENT_AGENTS=N` before invoking. For maximum-conservative runs (rate-limited keys, many heavy agents), lower it (3-4 is a safe floor that still permits Stage 1 parallelism).
+
+### Transient-failure backpressure (429 / rate-limit handling)
+
+A rate-limited dispatch is **not** a failed agent. It never started, leaves no `.partial` or `.md`, and would otherwise stay invisible until the 300s flux-watch timeout — exactly the gap that produces the ~30% retry-token waste cited above. The orchestrator must classify and respond the moment the `Agent` tool returns, **before** the timeout, using `scripts/flux-backoff.sh`.
+
+Three failure classes (see also `phases/shared-contracts.md` § Dispatch State Machine):
+
+| Class | Signal | Response |
+|-------|--------|----------|
+| **transient** | HTTP `429`, `rate_limit_error`, `overloaded_error`, `503`/`529`, "too many requests", capacity/quota | Do **not** count as failed. Back off + re-enqueue + decrease the cap. |
+| **terminal** | Usage-Policy refusal (`unable to respond … violate our Usage Policy`) | Deterministic — plain retry refuses again. Tier-downgrade per Step 2.3 "Synthetic refusal detection". |
+| **unknown** | crash, silent stall, anything else | Existing Retry Race Protocol / stall-rescue. No cap decrease. |
+
+Classify a returned agent's failure text (subagent transcript tail, or the Bash/Task error) with:
+```bash
+class=$(printf '%s' "$agent_error_text" | bash ${CLAUDE_PLUGIN_ROOT}/scripts/flux-backoff.sh classify)
+```
+
+**On `transient` (this is the enforced backpressure path):**
+
+1. **Multiplicatively decrease the effective cap** (congestion-control, applies for the rest of the run):
+   ```bash
+   bash ${CLAUDE_PLUGIN_ROOT}/scripts/flux-backoff.sh decrease {OUTPUT_DIR}   # cap /= 2, floored at 1
+   ```
+   This writes `{OUTPUT_DIR}/.dispatch-cap`; every subsequent `flux-dispatch.sh acquire` then admits against `min(MAX_CONCURRENT_AGENTS, .dispatch-cap)`, so the fan-out self-throttles without orchestrator bookkeeping.
+2. **Back off with exponential delay + full jitter** before re-enqueueing (decorrelates the retry storm so the whole wave doesn't re-hit the limit in lockstep):
+   ```bash
+   bash ${CLAUDE_PLUGIN_ROOT}/scripts/flux-backoff.sh sleep "$attempt"   # attempt is 1-based; sleeps base*2^(attempt-1) jittered
+   ```
+3. **Re-enqueue** the agent through the normal acquire → `Agent` → `wait` loop. It does **not** count toward the failed tally and does **not** get an error stub on this attempt.
+4. **Recovery (optional):** after a clean wave with no further 429s, additively restore one slot at a time:
+   ```bash
+   bash ${CLAUDE_PLUGIN_ROOT}/scripts/flux-backoff.sh increase {OUTPUT_DIR}   # +1, clears .dispatch-cap once back at base
+   ```
+
+Tunables (env → `budget.yaml` `dispatch.backoff.*` → defaults): `FLUX_BACKOFF_BASE_DELAY` (2s), `FLUX_BACKOFF_MAX_DELAY` (60s), `FLUX_BACKOFF_FACTOR` (2), `FLUX_BACKOFF_DECREASE_FACTOR` (2), `FLUX_BACKOFF_MIN_CAP` (1). `flux-dispatch.sh reset` clears any stale `.dispatch-cap` at the start of a run.
+
+A persistently-transient agent (still 429 after a small bounded number of re-enqueues, e.g. 3) is finally treated as `unknown` — write an error stub per `phases/shared-contracts.md` so synthesis sees it as data rather than looping forever.
 
 ### Step 2.2: Stage 1 — Launch top agents [review only]
 
@@ -310,6 +350,8 @@ Monitor via `bash ${CLAUDE_PLUGIN_ROOT}/scripts/flux-watch.sh {OUTPUT_DIR} {N} {
 **Progress display:** flux-watch.sh outputs progress lines as each agent completes: `[N/M | elapsed] agent-name`. Display these to the user as they arrive — this is the primary UX feedback during agent runs. Do not suppress or buffer this output.
 
 **Stall rescue (opt-in):** Pass `STALL_RESCUE=1`, `STALL_TIMEOUT=60` (default), and `EXPECTED_AGENTS=$(printf '%s\n' "${AGENT_NAMES[@]}")` to flux-watch.sh. When an expected agent has neither `.md` nor `.md.partial` after `STALL_TIMEOUT` seconds of no overall progress, flux-watch writes a `{agent}.md` stall stub (verdict: `error`, summary: `Agent stalled — no output within Ns of stall window`) and appends a `kind:stall` entry to `peer-findings.jsonl`. The stub increments `seen` so synthesis treats the stall as data, not silence. Saves up to 16 minutes of wall-clock per stalled agent (vs the full 300s timeout × N agents). Off by default for back-compat; turn on for any review where partial-progress synthesis is preferable to all-or-nothing.
+
+**Transient-failure check (do this BEFORE waiting out the timeout):** When an `Agent` call returns an error, or a dispatched agent has produced *neither* `.md` nor `.partial` shortly after dispatch, classify the error text with `flux-backoff.sh classify` (see § Transient-failure backpressure above). A `transient` (429/overloaded) result must engage backpressure immediately — `decrease` the cap, `sleep` the backoff, and re-enqueue — rather than waiting for the 300s flux-watch timeout. Only `unknown` results fall through to the Retry Race / stall-rescue paths below.
 
 **Completion verification:** List `{OUTPUT_DIR}/` — expect one `{agent-name}.{FLUX_RUN_UUID}.md` per agent (the run-uuid filename segment distinguishes this run's outputs from any concurrent run's). For `{agent}.{FLUX_RUN_UUID}.md.partial` only (incomplete): retry once via the **Retry Race Protocol** in `phases/shared-contracts.md` § Dispatch State Machine. Briefly: touch `{agent}.{FLUX_RUN_UUID}.abort`, rename the `.md.partial` to `.md.partial.aborted-<epoch>`, then sync retry with `run_in_background: false`, timeout 300000ms. Pre-retry guard: skip if the run-scoped `.md` exists (race with flux-watch return). If retry fails, write error stub per `phases/shared-contracts.md`. Cleanup: remove `.abort` markers; leave `.aborted-*` partials for post-mortem. Report: "N/M completed, K retried, J failed". When all agents complete, release the occupancy lock: `rmdir "$LOCK_DIR" 2>/dev/null || true` (also done in synthesize.md Step 3.7).
 

--- a/skills/flux-engine/phases/shared-contracts.md
+++ b/skills/flux-engine/phases/shared-contracts.md
@@ -79,6 +79,16 @@ Every agent moves through these states during a flux-drive run. Transitions are 
 - **An agent in `timeout_original_running` is treated as incomplete** (its `.partial` still exists). Orchestrator must retry or write an error stub before synthesis.
 - **`failed` agents leave a `.refused.md` or error-stub `.md`.** Synthesis includes them in counts but treats their findings as zero.
 - **A stall-rescued agent leaves a `{agent}.md` stall stub** (verdict `error`, `kind:stall` peer-finding) when `STALL_RESCUE=1` and no `.partial` or `.md` appears within `STALL_TIMEOUT` (default 60s) of any progress event. Synthesis treats stall stubs as failed (zero findings) but reports the stall in the run summary. Caller must pass `EXPECTED_AGENTS=$(printf '%s\n' "${AGENT_NAMES[@]}")` so flux-watch knows which agents are missing.
+- **A transient failure (429 / rate-limit / overloaded) is NOT a `failed` state.** It is a distinct class: the agent never started, leaves no `.partial`/`.md`, and must be re-enqueued with backoff rather than stubbed. It is the only failure class that **decreases** the effective concurrency cap (issue #9 backpressure). See § Transient-Failure Backpressure below. Only after a bounded number of transient re-enqueues does the agent fall through to `failed` (error stub).
+
+### Transient-Failure Backpressure (issue #9)
+
+Distinct from the Retry Race Protocol (which handles a `.partial` that never became `.md` — a *slow/crashed* agent at the **same** concurrency). A transient failure is rate-limit/overload backpressure and is owned by `scripts/flux-backoff.sh`, composing with the `flux-dispatch.sh` slot semaphore:
+
+- **Classify** the returned error text — `flux-backoff.sh classify` emits `transient | terminal | unknown`. Transient = HTTP `429`/`502`/`503`/`529`, `rate_limit_error`, `overloaded_error`, "too many requests", quota/capacity. Terminal = deterministic Usage-Policy refusal (tier-downgrade path, not plain retry). Unknown = crash/stall (Retry Race / stall-rescue).
+- **Exponential backoff + full jitter** — `flux-backoff.sh delay <attempt>` / `sleep <attempt>`. Window = `min(max_delay, base_delay × factor^(attempt-1))`; actual delay is uniform in `[0, window]` so the fan-out's retries decorrelate instead of re-hitting the limit in lockstep.
+- **Multiplicative decrease** — `flux-backoff.sh decrease {OUTPUT_DIR}` halves the effective cap (floored at `min_effective_cap`, default 1) by writing `{OUTPUT_DIR}/.dispatch-cap`. `flux-dispatch.sh acquire` admits against `min(MAX_CONCURRENT_AGENTS, .dispatch-cap)`, so the reduced ceiling throttles every later dispatch for the rest of the run (TCP/client-go congestion control). `flux-backoff.sh increase` additively recovers; `flux-dispatch.sh reset` clears the cap at run start.
+- **This must engage BEFORE the 300s timeout**, not after — a 429 leaves no filesystem artifact, so the orchestrator classifies the moment the `Agent` tool returns rather than waiting out flux-watch.
 
 ### Retry Race Protocol (Step 2.3)
 

--- a/tests/structural/test_backpressure.py
+++ b/tests/structural/test_backpressure.py
@@ -1,0 +1,198 @@
+"""Structural + behavioral checks for transient-failure backpressure (issue #9).
+
+Finding C-2: launch.md cited ~30% retry-token waste at 16-agent fan-out, yet
+dispatch had no 429/backoff handling. These tests pin the parts that make the
+backpressure path real: the enforcement script, its subcommands, the budget
+config it reads, the docs that describe the enforced path, and a few end-to-end
+behaviors (classification, decrease-floors-the-cap, and that flux-dispatch.sh
+acquire honors the decreased cap).
+"""
+
+import os
+import subprocess
+import tempfile
+
+import pytest
+import yaml
+
+
+@pytest.fixture(scope="session")
+def budget(project_root):
+    path = project_root / "config" / "flux-drive" / "budget.yaml"
+    return yaml.safe_load(path.read_text())
+
+
+@pytest.fixture()
+def output_dir():
+    with tempfile.TemporaryDirectory() as d:
+        yield d
+
+
+def _run(script, *args, env=None, input_text=None):
+    full_env = dict(os.environ)
+    if env:
+        full_env.update(env)
+    return subprocess.run(
+        ["bash", str(script), *args],
+        capture_output=True,
+        text=True,
+        env=full_env,
+        input=input_text,
+    )
+
+
+# --- script + subcommands exist ------------------------------------------
+
+def test_backoff_script_exists_and_executable(scripts_dir):
+    script = scripts_dir / "flux-backoff.sh"
+    assert script.exists(), "scripts/flux-backoff.sh (issue #9 backpressure) is missing"
+    assert os.access(script, os.X_OK), "flux-backoff.sh must be executable"
+
+
+def test_backoff_script_implements_subcommands(scripts_dir):
+    text = (scripts_dir / "flux-backoff.sh").read_text()
+    for sub in ("classify", "delay", "sleep", "decrease", "increase", "effective", "reset"):
+        assert f"{sub})" in text, f"flux-backoff.sh missing `{sub}` subcommand"
+
+
+def test_backoff_shares_dispatch_fd_204(scripts_dir):
+    """The congestion cap must be mutated under the SAME lock as the slot count
+    so decreases serialize with acquires (README fd-allocation rule)."""
+    text = (scripts_dir / "flux-backoff.sh").read_text()
+    assert "204" in text and ".dispatch-slots.lock" in text, (
+        "flux-backoff.sh must mutate the cap under the fd-204 dispatch-slots lock"
+    )
+
+
+# --- dispatch script wired to the congestion cap -------------------------
+
+def test_dispatch_reads_effective_cap(scripts_dir):
+    text = (scripts_dir / "flux-dispatch.sh").read_text()
+    assert "effective_max" in text, "flux-dispatch.sh acquire must compute an effective cap"
+    assert ".dispatch-cap" in text, "flux-dispatch.sh must read the congestion cap file"
+    assert "maxcap)" in text, "flux-dispatch.sh must expose maxcap for backoff seeding"
+
+
+# --- budget config ---------------------------------------------------------
+
+def test_budget_has_backoff_section(budget):
+    assert "dispatch" in budget
+    assert "backoff" in budget["dispatch"], "budget.yaml dispatch.backoff section missing"
+
+
+def test_backoff_config_values_are_positive(budget):
+    cfg = budget["dispatch"]["backoff"]
+    for key in ("base_delay_secs", "max_delay_secs", "factor",
+                "decrease_factor", "min_effective_cap"):
+        assert key in cfg, f"dispatch.backoff.{key} missing"
+        assert isinstance(cfg[key], int) and cfg[key] > 0, f"{key} must be a positive int"
+    assert cfg["decrease_factor"] >= 2, "decrease_factor must be >= 2 to actually decrease"
+    assert cfg["max_delay_secs"] >= cfg["base_delay_secs"]
+
+
+# --- docs describe the ENFORCED path -------------------------------------
+
+def test_launch_doc_documents_backpressure(project_root):
+    launch = (project_root / "skills" / "flux-engine" / "phases" / "launch.md").read_text().lower()
+    assert "flux-backoff.sh" in launch, "launch.md must reference the backpressure script"
+    assert "backpressure" in launch
+    assert "429" in launch or "rate-limit" in launch or "rate limit" in launch
+    # The distinguishing properties of the fix:
+    assert "jitter" in launch, "launch.md must document exponential backoff + jitter"
+    assert "decrease" in launch, "launch.md must document multiplicative concurrency decrease"
+
+
+def test_shared_contracts_documents_transient_class(project_root):
+    sc = (project_root / "skills" / "flux-engine" / "phases" / "shared-contracts.md").read_text()
+    low = sc.lower()
+    assert "transient" in low, "shared-contracts.md must name the transient failure class"
+    assert "flux-backoff.sh" in sc
+    # Must distinguish transient from the existing same-concurrency retry-race path.
+    assert "before the 300s timeout" in low or "before the 300s" in low
+
+
+def test_readme_registers_backoff_on_fd_204(scripts_dir):
+    readme = (scripts_dir / "README.md").read_text()
+    assert "flux-backoff.sh" in readme, "scripts/README.md must mention flux-backoff.sh"
+
+
+# --- behavioral: classification ------------------------------------------
+
+@pytest.mark.parametrize(
+    "text,expected",
+    [
+        ("API Error 429 Too Many Requests", "transient"),
+        ("rate_limit_error", "transient"),
+        ("overloaded_error", "transient"),
+        ("HTTP 503 Service Unavailable", "transient"),
+        ("HTTP 529 overloaded", "transient"),
+        (
+            "API Error: Claude Code is unable to respond to this request, "
+            "which appears to violate our Usage Policy",
+            "terminal",
+        ),
+        ("segmentation fault (core dumped)", "unknown"),
+        ("completed at 4290 tokens", "unknown"),  # a year-like number is not 429
+    ],
+)
+def test_classify_behavior(scripts_dir, text, expected):
+    r = _run(scripts_dir / "flux-backoff.sh", "classify", input_text=text)
+    assert r.returncode == 0, r.stderr
+    assert r.stdout.strip() == expected, f"{text!r} -> {r.stdout.strip()!r} (want {expected})"
+
+
+# --- behavioral: backoff bounds ------------------------------------------
+
+def test_delay_within_window_bounds(scripts_dir):
+    env = {"FLUX_BACKOFF_BASE_DELAY": "2", "FLUX_BACKOFF_FACTOR": "2", "FLUX_BACKOFF_MAX_DELAY": "10"}
+    # attempt 1 window = 2; attempt 6 raw = 64 capped at 10.
+    for _ in range(30):
+        d1 = int(_run(scripts_dir / "flux-backoff.sh", "delay", "1", env=env).stdout.strip())
+        assert 0 <= d1 <= 2
+        d6 = int(_run(scripts_dir / "flux-backoff.sh", "delay", "6", env=env).stdout.strip())
+        assert 0 <= d6 <= 10
+
+
+def test_delay_has_jitter(scripts_dir):
+    env = {"FLUX_BACKOFF_BASE_DELAY": "8", "FLUX_BACKOFF_MAX_DELAY": "60"}
+    vals = {
+        _run(scripts_dir / "flux-backoff.sh", "delay", "4", env=env).stdout.strip()
+        for _ in range(25)
+    }
+    assert len(vals) >= 2, "full jitter must produce varying delays"
+
+
+# --- behavioral: multiplicative decrease + composition -------------------
+
+def test_decrease_halves_and_floors(scripts_dir, output_dir):
+    dispatch = scripts_dir / "flux-dispatch.sh"
+    backoff = scripts_dir / "flux-backoff.sh"
+    _run(dispatch, "reset", output_dir, "6")
+    seq = [_run(backoff, "decrease", output_dir, "6").stdout.strip() for _ in range(4)]
+    assert seq == ["3", "2", "1", "1"], seq  # 6/2=3, 3->2, 2->1, floored at 1
+
+
+def test_acquire_honors_decreased_cap(scripts_dir, output_dir):
+    """The end-to-end guarantee: a 429-driven decrease throttles real acquires."""
+    dispatch = scripts_dir / "flux-dispatch.sh"
+    backoff = scripts_dir / "flux-backoff.sh"
+    _run(dispatch, "reset", output_dir, "6")
+    _run(backoff, "decrease", output_dir, "6")  # 6 -> 3
+    _run(backoff, "decrease", output_dir, "6")  # 3 -> 2 effective
+    # Two acquires succeed against the throttled cap of 2 ...
+    assert _run(dispatch, "acquire", output_dir, "6", "2").returncode == 0
+    assert _run(dispatch, "acquire", output_dir, "6", "2").returncode == 0
+    # ... the third must block/time out even though BASE max is 6.
+    assert _run(dispatch, "acquire", output_dir, "6", "1").returncode == 1
+    count = _run(dispatch, "count", output_dir).stdout.strip()
+    assert count == "2", count
+
+
+def test_reset_clears_congestion_cap(scripts_dir, output_dir):
+    dispatch = scripts_dir / "flux-dispatch.sh"
+    backoff = scripts_dir / "flux-backoff.sh"
+    _run(dispatch, "reset", output_dir, "6")
+    _run(backoff, "decrease", output_dir, "6")
+    assert os.path.exists(os.path.join(output_dir, ".dispatch-cap"))
+    _run(dispatch, "reset", output_dir, "6")
+    assert not os.path.exists(os.path.join(output_dir, ".dispatch-cap"))

--- a/tests/test_flux_backoff.bats
+++ b/tests/test_flux_backoff.bats
@@ -1,0 +1,200 @@
+#!/usr/bin/env bats
+# Tests for flux-backoff.sh — transient-failure backpressure (issue #9).
+# Covers: transient-vs-terminal-vs-unknown classification, exponential-backoff
+# timing/jitter bounds, multiplicative concurrency decrease + additive recovery,
+# and that flux-dispatch.sh acquire honors the decreased cap.
+
+bats_require_minimum_version 1.5.0
+
+setup() {
+    BACKOFF="$BATS_TEST_DIRNAME/../scripts/flux-backoff.sh"
+    DISPATCH="$BATS_TEST_DIRNAME/../scripts/flux-dispatch.sh"
+    OUTPUT_DIR="$(mktemp -d)"
+}
+
+teardown() {
+    [[ -d "$OUTPUT_DIR" ]] && rm -rf "$OUTPUT_DIR"
+}
+
+# --- classification -------------------------------------------------------
+
+@test "classify: HTTP 429 is transient" {
+    run bash -c "echo 'API Error 429 Too Many Requests' | '$BACKOFF' classify"
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == "transient" ]]
+}
+
+@test "classify: rate_limit_error is transient" {
+    run bash -c "echo 'rate_limit_error: please slow down' | '$BACKOFF' classify"
+    [[ "$output" == "transient" ]]
+}
+
+@test "classify: overloaded_error is transient" {
+    run bash -c "echo 'overloaded_error' | '$BACKOFF' classify"
+    [[ "$output" == "transient" ]]
+}
+
+@test "classify: 503/529 service errors are transient" {
+    run bash -c "echo 'HTTP 529 overloaded' | '$BACKOFF' classify"
+    [[ "$output" == "transient" ]]
+    run bash -c "echo 'Error: HTTP 503 Service Unavailable' | '$BACKOFF' classify"
+    [[ "$output" == "transient" ]]
+}
+
+@test "classify: Usage-Policy refusal is terminal, not transient" {
+    msg='API Error: Claude Code is unable to respond to this request, which appears to violate our Usage Policy'
+    run bash -c "echo '$msg' | '$BACKOFF' classify"
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == "terminal" ]]
+}
+
+@test "classify: crash/other is unknown" {
+    run bash -c "echo 'segmentation fault (core dumped)' | '$BACKOFF' classify"
+    [[ "$output" == "unknown" ]]
+}
+
+@test "classify: reads from a file argument" {
+    echo "rate limit exceeded" > "$OUTPUT_DIR/err.txt"
+    run bash "$BACKOFF" classify "$OUTPUT_DIR/err.txt"
+    [[ "$output" == "transient" ]]
+}
+
+@test "classify: a year like 4290 does not false-positive as 429" {
+    run bash -c "echo 'completed at 4290 tokens' | '$BACKOFF' classify"
+    [[ "$output" == "unknown" ]]
+}
+
+# --- backoff timing / jitter bounds --------------------------------------
+
+@test "delay: attempt 1 window is bounded by base_delay" {
+    # base=2 -> attempt 1 window is 2, full jitter picks in [0,2].
+    for _ in 1 2 3 4 5 6 7 8; do
+        run env FLUX_BACKOFF_BASE_DELAY=2 FLUX_BACKOFF_MAX_DELAY=60 bash "$BACKOFF" delay 1
+        [[ "$status" -eq 0 ]]
+        [[ "$output" -ge 0 ]]
+        [[ "$output" -le 2 ]]
+    done
+}
+
+@test "delay: window grows exponentially but is capped at max_delay" {
+    # base=2 factor=2 -> attempt 6 raw window = 2*2^5 = 64, capped at max=10.
+    for _ in 1 2 3 4 5 6 7 8; do
+        run env FLUX_BACKOFF_BASE_DELAY=2 FLUX_BACKOFF_FACTOR=2 FLUX_BACKOFF_MAX_DELAY=10 bash "$BACKOFF" delay 6
+        [[ "$output" -ge 0 ]]
+        [[ "$output" -le 10 ]]
+    done
+}
+
+@test "delay: full jitter actually varies across calls" {
+    seen=""
+    for _ in $(seq 1 20); do
+        d=$(env FLUX_BACKOFF_BASE_DELAY=8 FLUX_BACKOFF_MAX_DELAY=60 bash "$BACKOFF" delay 4)
+        seen="$seen $d"
+    done
+    # At least two distinct values must appear (jitter is not constant).
+    distinct=$(echo $seen | tr ' ' '\n' | sort -u | wc -l)
+    [[ "$distinct" -ge 2 ]]
+}
+
+@test "sleep: returns the delay and waits at least 0s, at most window" {
+    start=$(date +%s)
+    run env FLUX_BACKOFF_BASE_DELAY=2 FLUX_BACKOFF_MAX_DELAY=2 bash "$BACKOFF" sleep 1
+    end=$(date +%s)
+    [[ "$status" -eq 0 ]]
+    [[ "$output" -ge 0 ]]
+    [[ "$output" -le 2 ]]
+    [[ $((end - start)) -le 3 ]]
+}
+
+# --- multiplicative decrease / additive increase -------------------------
+
+@test "decrease: halves the effective cap (6 -> 3 -> 2 -> 1), floored" {
+    bash "$DISPATCH" reset "$OUTPUT_DIR" 6 >/dev/null
+    run bash "$BACKOFF" decrease "$OUTPUT_DIR" 6
+    [[ "$output" == "3" ]]
+    run bash "$BACKOFF" decrease "$OUTPUT_DIR" 6
+    [[ "$output" == "2" ]]
+    run bash "$BACKOFF" decrease "$OUTPUT_DIR" 6
+    [[ "$output" == "1" ]]
+    # Floor: never below min_effective_cap (default 1).
+    run bash "$BACKOFF" decrease "$OUTPUT_DIR" 6
+    [[ "$output" == "1" ]]
+}
+
+@test "decrease: respects FLUX_BACKOFF_MIN_CAP floor" {
+    bash "$DISPATCH" reset "$OUTPUT_DIR" 8 >/dev/null
+    run env FLUX_BACKOFF_MIN_CAP=2 bash "$BACKOFF" decrease "$OUTPUT_DIR" 8  # 8->4
+    [[ "$output" == "4" ]]
+    run env FLUX_BACKOFF_MIN_CAP=2 bash "$BACKOFF" decrease "$OUTPUT_DIR" 8  # 4->2
+    [[ "$output" == "2" ]]
+    run env FLUX_BACKOFF_MIN_CAP=2 bash "$BACKOFF" decrease "$OUTPUT_DIR" 8  # floored at 2
+    [[ "$output" == "2" ]]
+}
+
+@test "effective: reports min(base, congestion cap)" {
+    bash "$DISPATCH" reset "$OUTPUT_DIR" 6 >/dev/null
+    run bash "$BACKOFF" effective "$OUTPUT_DIR" 6
+    [[ "$output" == "6" ]]   # no congestion cap yet
+    bash "$BACKOFF" decrease "$OUTPUT_DIR" 6 >/dev/null  # cap -> 3
+    run bash "$BACKOFF" effective "$OUTPUT_DIR" 6
+    [[ "$output" == "3" ]]
+}
+
+@test "increase: additively recovers and clears the cap at base" {
+    bash "$DISPATCH" reset "$OUTPUT_DIR" 6 >/dev/null
+    bash "$BACKOFF" decrease "$OUTPUT_DIR" 6 >/dev/null  # 3
+    bash "$BACKOFF" decrease "$OUTPUT_DIR" 6 >/dev/null  # 2
+    run bash "$BACKOFF" increase "$OUTPUT_DIR" 6
+    [[ "$output" == "3" ]]
+    run bash "$BACKOFF" increase "$OUTPUT_DIR" 6
+    [[ "$output" == "4" ]]
+    run bash "$BACKOFF" increase "$OUTPUT_DIR" 6  # 5
+    run bash "$BACKOFF" increase "$OUTPUT_DIR" 6  # reaches base -> clears file, prints base
+    [[ "$output" == "6" ]]
+    [[ ! -e "$OUTPUT_DIR/.dispatch-cap" ]]
+}
+
+@test "reset (dispatch) clears a stale congestion cap from a prior run" {
+    bash "$DISPATCH" reset "$OUTPUT_DIR" 6 >/dev/null
+    bash "$BACKOFF" decrease "$OUTPUT_DIR" 6 >/dev/null
+    [[ -e "$OUTPUT_DIR/.dispatch-cap" ]]
+    bash "$DISPATCH" reset "$OUTPUT_DIR" 6 >/dev/null
+    [[ ! -e "$OUTPUT_DIR/.dispatch-cap" ]]
+}
+
+# --- composition: acquire honors the decreased cap -----------------------
+
+@test "acquire blocks at the decreased cap (backpressure engages)" {
+    bash "$DISPATCH" reset "$OUTPUT_DIR" 6 >/dev/null
+    bash "$BACKOFF" decrease "$OUTPUT_DIR" 6 >/dev/null  # 3
+    bash "$BACKOFF" decrease "$OUTPUT_DIR" 6 >/dev/null  # 2 effective
+    run bash "$DISPATCH" acquire "$OUTPUT_DIR" 6 2
+    [[ "$status" -eq 0 ]]
+    run bash "$DISPATCH" acquire "$OUTPUT_DIR" 6 2
+    [[ "$status" -eq 0 ]]
+    # Two slots claimed against the throttled cap of 2 — the third must NOT succeed,
+    # even though the BASE cap is 6.
+    run bash "$DISPATCH" acquire "$OUTPUT_DIR" 6 1
+    [[ "$status" -eq 1 ]]
+    run bash "$DISPATCH" count "$OUTPUT_DIR"
+    [[ "$output" == "2" ]]
+}
+
+@test "acquire ok line reports the effective (throttled) cap" {
+    bash "$DISPATCH" reset "$OUTPUT_DIR" 6 >/dev/null
+    bash "$BACKOFF" decrease "$OUTPUT_DIR" 6 >/dev/null  # 3
+    run bash "$DISPATCH" acquire "$OUTPUT_DIR" 6 2
+    [[ "$output" == "ok 1/3" ]]
+}
+
+@test "maxcap prints the BASE cap, ignoring the congestion cap" {
+    bash "$DISPATCH" reset "$OUTPUT_DIR" 6 >/dev/null
+    bash "$BACKOFF" decrease "$OUTPUT_DIR" 6 >/dev/null  # cap -> 3
+    run bash "$DISPATCH" maxcap "$OUTPUT_DIR" 6
+    [[ "$output" == "6" ]]
+}
+
+@test "unknown subcommand exits 2" {
+    run bash "$BACKOFF" bogus
+    [[ "$status" -eq 2 ]]
+}


### PR DESCRIPTION
Closes #9.

Adds a transient-failure class with TCP/client-go-style congestion control, composing with the flock dispatch semaphore from #5.

## Problem
Dispatch had no 429/backoff handling. The only retry was the synchronous Retry Race Protocol — same concurrency, no backoff — and it couldn't distinguish "rate-limited / never started" from "crashed" from "slow." A plain 429 left no `.md`/`.partial` and stayed invisible until the 300s flux-watch timeout.

## Mechanism
- **`scripts/flux-backoff.sh`** (new): `classify` (transient | terminal | unknown), `delay`/`sleep` (exponential backoff + full jitter), `decrease` (multiplicative, ceil-halved, floored at `min_effective_cap`), `increase` (additive recovery), `effective`, `reset`. Writes the congestion cap to `{OUTPUT_DIR}/.dispatch-cap` under the **same fd-204 dispatch-slots lock** — no new lock domain.
- **`scripts/flux-dispatch.sh`**: `acquire` now admits against **effective cap = min(base_max, .dispatch-cap)**, re-read each loop so a mid-run `decrease` throttles pending acquires. Added `maxcap` (seed cap); `reset` clears a stale cap.

## Changes
- `scripts/flux-backoff.sh` (new) — the backpressure engine.
- `scripts/flux-dispatch.sh` — wire congestion cap into admission control.
- `config/flux-drive/budget.yaml` — `dispatch.backoff` tunables.
- `skills/flux-engine/phases/launch.md` — documents the enforced path (classify before the 300s timeout, decrease + jittered re-enqueue, classification table). Scoped to the concurrency/Step-2.3 sections.
- `skills/flux-engine/phases/shared-contracts.md` — adds the transient-failure class to the Dispatch State Machine (narrow, localized — left #11's sanitization territory untouched).
- `scripts/README.md` — fd-204 row notes the shared lock.
- Tests: `tests/test_flux_backoff.bats` (21) + `tests/structural/test_backpressure.py`.

## Tests
- `uv run pytest -q` → **207 passed** (+25).
- `npx bats tests/test_flux_backoff.bats` → 21/21; regression `test_flux_dispatch.bats` → 10/10.

## Note
The "persistently-transient after N re-enqueues → error stub" cutoff is documented as prose in `launch.md` (orchestrator-owned, since only the LLM tracks per-agent attempt counts across re-dispatches); the scripts own the deterministic classify/backoff/cap mechanics.

Related: builds directly on #5 / PR #7 (dispatch semaphore). Touches `shared-contracts.md` + `launch.md` — scoped to different sections than #11.

https://claude.ai/code/session_01VBqxaqMHtjoGXFuS1d4ui2

---
_Generated by [Claude Code](https://claude.ai/code/session_01VBqxaqMHtjoGXFuS1d4ui2)_