### PR TITLE
flux-melange: multi-runtime peer mirrors (claude/codex/hermes) + Parley equilibrium exchange

### DIFF
--- a/commands/flux-melange.md
+++ b/commands/flux-melange.md
@@ -3,10 +3,12 @@ name: flux-melange
 description: "Goal-seeking spice loop — adaptive review rounds steer toward the heat (novelty/risk/disagreement) found so far, fuse high-tension lens pairs into hybrid intersection-detectors, score every finding on Novelty/Risk/Taste, and surface the spice."
 user-invocable: true
 codex-aliases: [flux-melange]
-argument-hint: "<path, dir, or inline text> [--goal=\"...\"] [--weights=balanced|risk-hunt|taste|novelty] [--max-rounds=N] [--budget=N] [--quality=economy|balanced|max] [--fusion=auto|N|off] [--verify=auto|off|all] [--interactive]"
+argument-hint: "<path, dir, or inline text> [--goal=\"...\"] [--weights=balanced|risk-hunt|taste|novelty] [--max-rounds=N] [--budget=N] [--quality=economy|balanced|max] [--fusion=auto|N|off] [--verify=auto|off|all] [--peers=off|auto|codex[:model],hermes[:model]] [--exchange-rounds=N] [--interactive]"
 ---
 
 Use the `interflux:flux-melange-engine` skill to run a goal-seeking, multi-round deep review of the target. Pass `$ARGUMENTS` through verbatim. The skill owns charter parsing, the seed round, the heat-ledger control loop (assay → retarget → probe → verify → score → loop gate), runtime lens fusion, and the surfacing-first synthesis.
+
+With `--peers=auto` (or an explicit `codex[:model],hermes[:model]` list), the same loop also runs as epistemically independent mirrors on whichever external agent runtimes are detected (Codex CLI, Hermes Agent), each producing its own synthesis; a Parley phase then exchanges the syntheses adversarially until they reach epistemic equilibrium, and any residual disagreements are surfaced to the user to tie-break.
 
 `flux-melange` is the apex of the interflux escalation ladder — `flux-drive` (single triaged pool) → `flux-review` (fixed N tracks at static semantic distances, blind fan-out, convergence synthesis) → `flux-explore` (autonomous rounds, but monotonically *further out*) → **`flux-melange`** (a *closed loop*: each round's targeting is a function of what the previous round found, lenses *combine* instead of only aggregating, and findings rank on Novelty/Risk/Taste, not severity alone). See `docs/guide-choosing-flux-command.md` for when to reach for which.
 

--- a/config/flux-melange/defaults.yaml
+++ b/config/flux-melange/defaults.yaml
@@ -84,6 +84,30 @@ verify:
   novelty_gate: 2        # verify if novelty >= this ...
   risk_gate: 9           # ... OR risk.product >= this
 
+# --- Peer runtimes ------------------------------------------------------------
+#
+# Multi-runtime mirrors (references/peer-runtimes.md): run the SAME loop as
+# epistemically independent mirrors on external agent CLIs, then reconcile the
+# syntheses in the Parley phase (phases/parley.md) — adversarial exchange to
+# epistemic equilibrium, residual disagreements to the user for tie-break.
+# Cost multiplies: N mirrors ~= (N+1)x slots, plus external provider billing.
+#
+# mode: off | auto (detect via scripts/detect-runtimes.sh) | explicit flag list
+# invoke templates are CONFIG so CLI drift is fixable without engine changes;
+# {model} and {projectRoot} are resolved by charter, {promptfile} by the shim.
+#
+peers:
+  mode: off
+  runtimes:
+    codex:
+      model: gpt-5.6-sol
+      invoke: 'cd {projectRoot} && codex exec --full-auto --skip-git-repo-check -c model="{model}" - < {promptfile}'
+    hermes:
+      model: null          # null = the hermes CLI's configured default model
+      invoke: 'cd {projectRoot} && hermes -z "$(cat {promptfile})"{model_flag} --yolo'   # {model_flag} = " -m {model}" when model set, else ""
+  exchange:
+    max_rounds: 3          # Parley cap; fixed point usually lands in 1-2
+
 # --- Quality / model routing ------------------------------------------------
 #
 # economy = all Sonnet (+ skip taste). balanced = Opus on creative/judgment

--- a/config/flux-melange/defaults.yaml
+++ b/config/flux-melange/defaults.yaml
@@ -96,15 +96,22 @@ verify:
 # invoke templates are CONFIG so CLI drift is fixable without engine changes;
 # {model} and {projectRoot} are resolved by charter, {promptfile} by the shim.
 #
+# TRUST BOUNDARY (peer-runtimes.md § Trust boundary): these templates run
+# external agents with AUTO-APPROVED tool use — codex --full-auto is sandboxed
+# to workspace-write in projectRoot; hermes --yolo is NOT sandboxed. Only
+# enable --peers on targets/repos you trust. {model} values are validated
+# (letters/digits/._:- only) at both charter and the workflow chokepoint
+# before substitution; paths stay double-quoted in the templates.
+#
 peers:
   mode: off
   runtimes:
     codex:
       model: gpt-5.6-sol
-      invoke: 'cd {projectRoot} && codex exec --full-auto --skip-git-repo-check -c model="{model}" - < {promptfile}'
+      invoke: 'cd "{projectRoot}" && codex exec --full-auto --skip-git-repo-check -c model="{model}" - < "{promptfile}"'
     hermes:
       model: null          # null = the hermes CLI's configured default model
-      invoke: 'cd {projectRoot} && hermes -z "$(cat {promptfile})"{model_flag} --yolo'   # {model_flag} = " -m {model}" when model set, else ""
+      invoke: 'cd "{projectRoot}" && hermes -z "$(cat "{promptfile}")"{model_flag} --yolo'   # {model_flag} = " -m {model}" when model set, else ""
   exchange:
     max_rounds: 3          # Parley cap; fixed point usually lands in 1-2
 

--- a/scripts/detect-runtimes.sh
+++ b/scripts/detect-runtimes.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# detect-runtimes.sh — probe which peer agent runtimes are available for
+# flux-melange --peers=auto (references/peer-runtimes.md).
+#
+# Emits ONE JSON object on stdout:
+#   {"claude":{"available":true,"host":true},
+#    "codex":{"available":true,"version":"codex-cli 0.144.4"},
+#    "hermes":{"available":false,"version":null}}
+#
+# "Available" means the CLI is on PATH and answers --version. Auth state is
+# NOT probed here (auth prompts can hang a headless check); an unauthenticated
+# CLI surfaces at probe time and the mirror degrades gracefully via the shim's
+# SHIM-FAILURE contract. Exit code is always 0 — absence is data, not an error.
+set -uo pipefail
+
+probe() {
+  local bin="$1"
+  local ver=""
+  if command -v "$bin" >/dev/null 2>&1; then
+    ver="$("$bin" --version 2>/dev/null | head -1 | tr -d '"' || true)"
+    printf '{"available":true,"version":"%s"}' "${ver}"
+  else
+    printf '{"available":false,"version":null}'
+  fi
+}
+
+printf '{"claude":{"available":true,"host":true},"codex":%s,"hermes":%s}\n' \
+  "$(probe codex)" "$(probe hermes)"

--- a/skills/flux-melange-engine/SKILL.md
+++ b/skills/flux-melange-engine/SKILL.md
@@ -44,7 +44,8 @@ The **heat ledger** is the only genuinely new object. See `references/ledger-sch
 | 5 — Verify | `phases/verify.md` | **Conditional** cheap-model pass: re-read cited locations for high-novelty / high-risk findings only; stamp `upheld` / `refuted`. |
 | 6 — Score + loop gate | `phases/score.md` | Assay the round, link convergence/disagreement refs across the whole ledger, decrement budget, evaluate the continue predicate → write `should_stop`. |
 | 7 — Synthesize | `phases/synthesize.md` | One Opus agent (the **eye of distance**) over the full ledger surfaces the five views + spice trail; write dated `synthesis.md`. |
-| 8 — Report | inline below | Print ledger + synthesis paths, the per-round hotspot/directive trail, halt reason, total cost, regeneration hints. |
+| 7.5 — Parley | `phases/parley.md` | Only with `--peers` (`references/peer-runtimes.md`): phases 1–7 also ran as independent mirrors on external runtimes (codex/hermes); per-runtime advocates now adversarially exchange concessions/challenges until a moderator detects the fixed point (**epistemic equilibrium**); residual contested topics go to the user for tie-break. |
+| 8 — Report | inline below | Print ledger + synthesis paths, the per-round hotspot/directive trail, halt reason, total cost, regeneration hints; with peers: the equilibrium verdict + contested-topic tie-break. |
 
 The loop is **Phase 3 → 4 → 5 → 6**, re-entering from 6 to 3 while `should_stop == false`.
 
@@ -63,6 +64,8 @@ After charter, choose the execution path. Use the **workflow path** when ALL of:
 3. **Not resuming a prose-mode run** (a non-empty `heat-ledger.jsonl` with no prior workflow run for this SLUG → finish on the prose path).
 
 Otherwise run the **prose path** (Steps 1–3 below). The phase files are the spec for both paths.
+
+**Peer mirrors require the workflow path.** When charter resolved `--peers` (see `phases/charter.md` § Resolve peer runtimes and `references/peer-runtimes.md`) but the prose path is forced (`--interactive`, no Workflow tool), warn and run the primary loop only — the mirror loops and Parley exist only in the script in v1.
 
 **Workflow path:**
 
@@ -127,10 +130,28 @@ To rerun the discovered lenses as a flat review: /flux-drive {INPUT_PATH}
 To regenerate a fused lens: /flux-gen --from-specs .claude/flux-gen-specs/{SLUG}-fusion-{k}.json
 ```
 
+With `--peers`, append (from the report's `peers` + `equilibrium` fields):
+```
+Peer mirrors:
+  {runtime} ({model}): {rounds} rounds (halt {reason}), {upheld}/{total} upheld — synthesis: {path}
+  {or: "{runtime}: FAILED — {caveat}"}
+
+Parley: {rounds} exchange round(s) — equilibrium {REACHED | NOT REACHED (capped)}
+Consensus: {agreed_count} claims   Contested: {n} topics
+Equilibrium:    {OUTPUT_ROOT}/equilibrium.md
+Disagreements:  {OUTPUT_ROOT}/disagreements.jsonl
+```
+
+**Tie-break (orchestrator only — never inside the workflow):** if `equilibrium.contested` is
+non-empty, present the top topics by heat (≤ 4) via `AskUserQuestion` — one question per topic,
+each runtime's argument as an option (plus "both partially right" / "defer"), attributed by
+runtime. Append the rulings to `equilibrium.md` under `## Rulings` and mention any topics left
+unruled. In non-interactive contexts, list the contested table in the report instead of asking.
+
 ## Notes
 
 - **Crash-safety.** Every phase only *appends* findings or *rewrites status fields* — it never mutates a claim. A mid-loop crash leaves a replayable ledger; rerunning resumes from the last completed round.
 - **Three independent halts** plus an optional soft one: **DRY** (yield → 0), **BUDGET** (accumulator exhausted, hard), **CEILING** (`max_rounds`), and — only in `--interactive` — **GOAL-MET** (AskUserQuestion: keep spending?). `min_rounds = 2` guards against one unlucky round quitting the loop early.
 - **The steering signal is decoupled from raw novelty.** Heat = novelty × risk *yield-density*, not novelty alone — otherwise "go toward novelty" + "novelty = unexplored" manufactures a shallow-novel trickle that never lets DRY fire. `STEER-WIDE` is therefore a *reserved* directive, not forced every round.
-- **Degraded modes.** If `interlens` MCP tools (`combine_lenses` / `find_contrasting_lenses`) are unavailable, fusion falls back to controller heuristics over lens records — an accelerant, not a dependency. If a probe fails, its directive is dropped and the round proceeds with survivors (same graceful-degradation posture as flux-review tracks).
+- **Degraded modes.** If `interlens` MCP tools (`combine_lenses` / `find_contrasting_lenses`) are unavailable, fusion falls back to controller heuristics over lens records — an accelerant, not a dependency. If a probe fails, its directive is dropped and the round proceeds with survivors (same graceful-degradation posture as flux-review tracks). Peer mirrors extend this posture: an undetected runtime is skipped at charter, a dead mirror becomes a caveat (primary unaffected), and Parley is skipped below 2 surviving syntheses (`references/peer-runtimes.md` § Failure semantics).
 - **Relationship to convergence.** flux-review's cross-track convergence is preserved but *reframed and demoted*: high convergence = high confidence but LOW novelty (commodity you can trust but shouldn't be excited by). It is one synthesis section, no longer the headline.

--- a/skills/flux-melange-engine/phases/charter.md
+++ b/skills/flux-melange-engine/phases/charter.md
@@ -52,10 +52,16 @@ OUTPUT_ROOT   = {PROJECT_ROOT}/docs/research/flux-melange/{SLUG}
 3. Per surviving runtime, resolve the model (flag `rt:model` > project yaml > plugin defaults)
    and bake the invoke template: substitute `{model}`/`{model_flag}` and `{projectRoot}`, leaving
    only `{promptfile}` for the shim. Result: `PEERS = [{kind, model, invoke}]`.
+   **Validate before baking** (the values land inside shell commands): runtime kind must match
+   `^[a-z][a-z0-9-]{1,15}$`, model must match `^[A-Za-z0-9._:-]{1,64}$` — REJECT the flag
+   otherwise (the workflow script re-validates at its chokepoint and will throw). Keep the
+   template's double quotes around `{projectRoot}` and `{promptfile}`.
 4. Create per-mirror artifact dirs: `OUTPUT_ROOT/mirrors/{kind}/lenses/` and an empty
    `OUTPUT_ROOT/mirrors/{kind}/heat-ledger.jsonl` for each peer.
-5. Add to the plan display: `Peers: {kind (model), ...} — cost ~×(N+1) slots + external billing`,
-   and pass `peers` + `exchange` through to the workflow args (references/workflow-args.md).
+5. Add to the plan display: `Peers: {kind (model), ...} — cost ~×(N+1) slots + external billing`
+   plus the trust warning: `⚠ peer mirrors run external CLIs with auto-approved tool use
+   (codex: workspace-write sandbox; hermes: unsandboxed)`. Pass `peers` + `exchange` through to
+   the workflow args (references/workflow-args.md).
 
 Peer mirrors REQUIRE the workflow fast-path: in `--interactive` (prose path) warn and run the
 primary loop only.

--- a/skills/flux-melange-engine/phases/charter.md
+++ b/skills/flux-melange-engine/phases/charter.md
@@ -16,6 +16,8 @@ Parse `$ARGUMENTS`:
 | `--quality=economy\|balanced\|max` | `balanced` | model routing (see `references/budget-ladder.md`) |
 | `--fusion=auto\|N\|off` | `auto` | fusions/round (auto = ≤ 2; depth-2 only on `--quality=max`) |
 | `--verify=auto\|off\|all` | `auto` | `auto` = gated on `novelty ≥ 2 OR risk.product ≥ 9` |
+| `--peers=off\|auto\|<rt>[:<model>],...` | `off` | multi-runtime mirrors + Parley (see § Resolve peer runtimes; `references/peer-runtimes.md`) |
+| `--exchange-rounds=N` | `3` | Parley exchange cap (fixed point usually lands earlier) |
 | `--interactive` | off | restores per-round confirmation + the GOAL-MET soft-stop prompt |
 
 If the argument is empty, use `AskUserQuestion` to get a target. If it is not a valid path on disk, treat it as inline text (`INPUT_TYPE = text`).
@@ -41,6 +43,22 @@ GOAL          = resolved --goal text
 WEIGHTS       = resolved --weights
 OUTPUT_ROOT   = {PROJECT_ROOT}/docs/research/flux-melange/{SLUG}
 ```
+
+## Resolve peer runtimes (only when `--peers` ≠ off)
+
+1. Run `bash ${CLAUDE_PLUGIN_ROOT}/scripts/detect-runtimes.sh` (emits one JSON object; exit 0 always).
+2. `auto` → every detected runtime; explicit list → keep detected entries, log-and-skip the rest
+   (never an error). Claude is always the primary, never a peer.
+3. Per surviving runtime, resolve the model (flag `rt:model` > project yaml > plugin defaults)
+   and bake the invoke template: substitute `{model}`/`{model_flag}` and `{projectRoot}`, leaving
+   only `{promptfile}` for the shim. Result: `PEERS = [{kind, model, invoke}]`.
+4. Create per-mirror artifact dirs: `OUTPUT_ROOT/mirrors/{kind}/lenses/` and an empty
+   `OUTPUT_ROOT/mirrors/{kind}/heat-ledger.jsonl` for each peer.
+5. Add to the plan display: `Peers: {kind (model), ...} — cost ~×(N+1) slots + external billing`,
+   and pass `peers` + `exchange` through to the workflow args (references/workflow-args.md).
+
+Peer mirrors REQUIRE the workflow fast-path: in `--interactive` (prose path) warn and run the
+primary loop only.
 
 ## Initialize ledger + state
 

--- a/skills/flux-melange-engine/phases/parley.md
+++ b/skills/flux-melange-engine/phases/parley.md
@@ -1,0 +1,70 @@
+# Phase 7.5 — Parley (adversarial synthesis exchange to epistemic equilibrium)
+
+Runs ONLY when the charter resolved peer mirrors (`--peers`, references/peer-runtimes.md) and at
+least two runtimes produced a synthesis. Where the melange loop steers *probes* toward heat,
+Parley steers the *syntheses themselves* into collision: each runtime fields an advocate, the
+advocates exchange concessions and challenges over the same evidence, and the exchange repeats
+until it reaches a **fixed point** — a round in which no advocate changes its mind, introduces
+new evidence, or surfaces a novel insight. That fixed point is the run's *epistemic
+equilibrium*. What remains contested at equilibrium is not noise to average away — it is the
+run's most valuable residue, and it goes to the **user** for tie-break.
+
+## Why exchange instead of merge
+
+A merge (one agent reads all syntheses and reconciles) launders disagreement: the merging model's
+own priors silently win every close call, and cross-model disagreement — the entire reason to run
+mirrors — is destroyed at the moment it is most informative. The exchange keeps each runtime's
+epistemic position *alive and attributed* until it is either genuinely conceded (evidence, not
+authority) or explicitly surfaced as contested.
+
+## Participants
+
+| Role | Who runs it | Model |
+|------|-------------|-------|
+| Advocate (one per runtime) | primary: native agent; mirrors: shim-relay to the external CLI — the external model argues its own case | `advocate` routing (Opus at balanced) / external model |
+| Moderator (one) | always a native agent | `moderator` routing (Opus at balanced) |
+
+The moderator merges and bookkeeps; it never argues, never scores who "won", and never resolves
+a contested topic itself. Structural neutrality is what makes the equilibrium claim honest.
+
+## The exchange round
+
+1. **Advocates (parallel).** Each advocate reads all syntheses, the target, and the prior
+   consensus table, then emits positions:
+   - `concede` — accept a peer claim you missed or contradicted (state what changed your mind)
+   - `challenge` — dispute a peer claim (concrete evidence from the target/repo REQUIRED)
+   - `affirm` — stand by your claim under challenge (NEW evidence required; repetition is void)
+   - `novel` — a genuinely new insight the collision exposed
+   plus `changed_mind` (true iff any concession, new evidence, or novel insight this round).
+2. **Moderator.** Merges positions into a consensus table: `agreed` (claims all advocates now
+   hold, holders recorded) and `contested` (live disputes: every runtime's current argument +
+   evidence + a heat score 0–9 for how consequential the disagreement is). Stale repetition
+   carries no weight. Sets `changed` = any advocate changed_mind OR the table materially moved.
+3. **Fixed-point test.** `changed == false` → equilibrium reached, exchange ends. Otherwise
+   loop, up to `exchange.max_rounds` (default 3; ending at the cap with `changed == true` is
+   reported as equilibrium NOT reached — an honest "still moving when we stopped").
+
+## Artifacts
+
+- `{OUTPUT_ROOT}/equilibrium.md` — frontmatter (`artifact_type: melange-equilibrium`,
+  runtimes, exchange_rounds, equilibrium: true/false) + Consensus / Contested / Exchange-log
+  sections. Rewritten each round; the final round's version stands.
+- `{OUTPUT_ROOT}/disagreements.jsonl` — one line per contested topic:
+  `{"topic","heat","positions":[{"runtime","argument","evidence"}]}`. This is the tie-break
+  queue.
+
+## User tie-break (orchestrator, not this phase)
+
+Scripts and subagents cannot `AskUserQuestion`. The workflow returns `equilibrium.contested`
+to the orchestrator, which (SKILL.md § Report) presents the top contested topics by heat —
+each side's argument attributed by runtime — for the user to rule on. Rulings are appended to
+`equilibrium.md` under `## Rulings`. In non-interactive contexts the contested table is simply
+surfaced in the report; unruled disagreements remain open and are honest to leave open.
+
+## Degraded modes
+
+- A mirror whose loop failed simply doesn't field an advocate; with < 2 surviving syntheses the
+  phase is skipped with a caveat (never an error).
+- A failed advocate call drops that runtime from the round; the moderator proceeds with
+  survivors and notes the absence.
+- A failed moderator call halts the exchange with the last known table (`equilibrium: false`).

--- a/skills/flux-melange-engine/references/peer-runtimes.md
+++ b/skills/flux-melange-engine/references/peer-runtimes.md
@@ -1,0 +1,104 @@
+# Reference: Peer Runtimes — Multi-Runtime Mirrors & the Transport Shim
+
+`--peers` runs the SAME melange loop as epistemically independent mirrors on external agent
+runtimes (Codex CLI, Hermes Agent), each with its own ledger, lenses, and synthesis, then
+reconciles the syntheses in the Parley phase (phases/parley.md). This reference owns the
+detection contract, the shim contract, isolation rules, and cost math.
+
+## Flag
+
+```
+--peers=off | auto | <runtime>[:<model>][,<runtime>[:<model>]...]
+```
+
+- `off` (default) — classic single-runtime melange.
+- `auto` — run `scripts/detect-runtimes.sh` and mirror on every available runtime, using
+  per-runtime default models from config.
+- Explicit list — e.g. `--peers=codex:gpt-5.6-sol,hermes`. A runtime that fails detection is
+  logged and skipped (the run proceeds; never an error).
+- `--exchange-rounds=N` (default 3) caps the Parley exchange.
+
+## Detection
+
+`scripts/detect-runtimes.sh` probes PATH + `--version` for `codex` and `hermes` and emits one
+JSON object. It does NOT probe auth (headless auth checks can hang); an unauthenticated CLI
+surfaces at probe time as a SHIM-FAILURE and the mirror degrades per its normal failure path.
+The orchestrator (charter) runs detection — the workflow script never does its own.
+
+## Invocation templates (config: `peers.runtimes.*.invoke`)
+
+Resolved by charter (model and cwd baked in), passed to the workflow in `args.peers[].invoke`
+with a single `{promptfile}` placeholder that the shim substitutes:
+
+| Runtime | Template (default) |
+|---------|--------------------|
+| codex | `cd {projectRoot} && codex exec --full-auto --skip-git-repo-check -c model="{model}" - < {promptfile}` |
+| hermes | `cd {projectRoot} && hermes -z "$(cat {promptfile})" [-m {model}] --yolo` |
+
+Notes: `codex exec` (never bare `codex` — that opens interactive mode); `--full-auto` =
+workspace-write sandbox + auto-approval; `--skip-git-repo-check` because melange targets are
+not always inside a git repo. Hermes `-z` is the headless one-shot; `--yolo` auto-accepts tool
+use so mirror probes can write findings files. Both templates are config, not code — fix CLI
+drift in `flux-melange.yaml` without touching the engine.
+
+## The transport shim
+
+Workflow scripts can only spawn Claude agents, so each mirror call is relayed by a **shim**: a
+haiku agent whose entire charter is *run the task on the external CLI and relay the structured
+output verbatim*. Rules the shim enforces:
+
+1. Writes the task prompt to `{outputRoot}/mirrors/{kind}/tmp/` and appends the JSON Schema the
+   external model must satisfy (the same schema the native path validates against).
+2. One Bash call, 600s timeout, using the invocation template.
+3. Extracts the FINAL JSON object from stdout; on parse failure re-asks the external CLI once.
+4. Relays verbatim — the shim never adds, drops, merges, rescores, or rewords. Shim model is
+   haiku *by construction*: transport must stay too dumb to contaminate the mirror's
+   independence.
+5. On CLI absence / double failure / timeout: returns a minimally valid object with
+   `SHIM-FAILURE: <reason>` in a required string field, so the loop's existing
+   survivor-degradation handles it.
+
+Schema validation still happens at the shim's own tool-call layer, so malformed external output
+retries hit the shim (which re-asks the CLI), not the controller.
+
+## Isolation (what keeps mirrors epistemically independent)
+
+- Own artifact tree: `{OUTPUT_ROOT}/mirrors/{kind}/` (ledger, lenses, round dirs, synthesis,
+  surfaced.jsonl, run-manifest.json). The primary keeps the classic root paths, so resume
+  tooling and fetch-findings are unaffected.
+- Own lens namespace: generated fd-* agent names carry a per-runtime suffix (`-cox` for codex,
+  `-hex` for hermes — first two letters + `x`), and spec files carry a `-{kind}` tag, so the
+  shared `.claude/agents/` directory never collides and `--mode=skip-existing` never
+  cross-contaminates.
+- No shared state: mirrors never read the primary's ledger, findings, or lens records (and vice
+  versa) until Parley — where the collision is the point, and it happens over *syntheses*, with
+  attribution, not over raw pools.
+- The seed's distant-tier constraints, fusion charter, and verify gates apply identically in
+  mirrors — same shape, different mind.
+
+## Cost & budget
+
+Each mirror gets its own slot pool equal to the primary's (`budget.totalSlots`) and decrements
+it by measured dispatch exactly like the primary — so `--peers` with N mirrors costs roughly
+(N+1)× the single-runtime run in slots, plus the external providers' own billing (not metered
+here; shims are haiku-cheap). Parley adds ≤ `(runtimes + 1) × exchange.max_rounds` agent calls
+outside the slot pools. Charter multiplies the plan display accordingly; the 30-slot hard cap
+applies per loop, not to the sum.
+
+## Failure semantics
+
+| Failure | Effect |
+|---------|--------|
+| Runtime not detected | skipped at charter; logged in plan |
+| Mirror loop dies (seed produces no lenses, both seed probes fail) | mirror reported `failed`, caveat added; primary unaffected |
+| Primary loop dies | whole workflow errors (unchanged from classic behavior) |
+| Shim double-failure on one call | that call degrades exactly like a native probe failure (survivors proceed) |
+| < 2 syntheses at Parley | phase skipped with caveat |
+
+## Relationship to interpeer
+
+interpeer's council/mine modes are interactive, command-level cross-AI review. Parley is the
+same epistemology embedded in the melange workflow: independent full loops instead of one-shot
+second opinions, and a fixed-point exchange instead of single-round disagreement extraction.
+If you want a quick cross-model take on a diff, use interpeer; if you want two (or three)
+complete adaptive reviews that then argue to equilibrium, use `--peers`.

--- a/skills/flux-melange-engine/references/peer-runtimes.md
+++ b/skills/flux-melange-engine/references/peer-runtimes.md
@@ -85,6 +85,25 @@ here; shims are haiku-cheap). Parley adds ≤ `(runtimes + 1) × exchange.max_ro
 outside the slot pools. Charter multiplies the plan display accordingly; the 30-slot hard cap
 applies per loop, not to the sum.
 
+## Trust boundary
+
+Peer mirrors run external agents with **auto-approved tool use** — that is what makes headless
+mirrors possible, and it is a real permission decision, not an implementation detail:
+
+- `codex exec --full-auto` = workspace-write **sandbox scoped to projectRoot** + auto-approval.
+- `hermes --yolo` = auto-approval with **no sandbox**. Prefer codex-only `--peers` on repos you
+  do not fully trust; enable the hermes mirror only where an unsandboxed agent is acceptable.
+- Only enable `--peers` at all on targets/repos you trust: mirror probes read the target and
+  repo files and write findings artifacts, and prompt content includes prior agents' output.
+
+Injection hardening: `kind` and `model` are the only externally-influenced strings interpolated
+into shell command lines, and both are regex-validated twice — at charter
+(`^[a-z][a-z0-9-]{1,15}$` / `^[A-Za-z0-9._:-]{1,64}$`) and again at the workflow script's parse
+chokepoint (which throws). Templates keep `{projectRoot}`/`{promptfile}` double-quoted; the shim
+constrains prompt filenames to `[a-z0-9-]`. Invoke templates themselves are **trusted config**
+(plugin defaults or the project's own `flux-melange.yaml`) — a hostile project config is already
+outside this threat model, same as hooks.
+
 ## Failure semantics
 
 | Failure | Effect |

--- a/skills/flux-melange-engine/references/workflow-args.md
+++ b/skills/flux-melange-engine/references/workflow-args.md
@@ -40,9 +40,19 @@ Charter (Phase 0) resolves these exactly as for the prose path, then passes them
   "loop": { "maxRounds": 4, "minRounds": 2, "diminishingThreshold": 1, "wideThreshold": 0.6 },
   "seed": { "adjacent": 3, "distant": 2 },
   "fusion": { "perRoundCap": 2, "sharedHeatGate": 2 },
-  "verify": { "mode": "auto | off | all", "noveltyGate": 2, "riskGate": 9 }
+  "verify": { "mode": "auto | off | all", "noveltyGate": 2, "riskGate": 9 },
+
+  "peers": [ { "kind": "codex", "model": "gpt-5.6-sol", "invoke": "cd /abs/project && codex exec --full-auto --skip-git-repo-check -c model=\"gpt-5.6-sol\" - < {promptfile}" } ],
+  "exchange": { "maxRounds": 3 }
 }
 ```
+
+`peers` and `exchange` are OPTIONAL (all other keys are required): omit both for a classic
+single-runtime run. When present, `peers[].invoke` must be fully resolved except the
+`{promptfile}` placeholder (the shim substitutes it), and charter must pre-create
+`OUTPUT_ROOT/mirrors/{kind}/lenses/` + each mirror's empty `heat-ledger.jsonl`. See
+`references/peer-runtimes.md` for detection, isolation, and failure semantics, and
+`phases/parley.md` for the exchange the script runs after the mirror syntheses.
 
 `date` and `slug` MUST come from the charter — Workflow scripts cannot call `Date.now()` / `new Date()`.
 

--- a/skills/flux-melange-engine/workflow/melange-workflow.js
+++ b/skills/flux-melange-engine/workflow/melange-workflow.js
@@ -44,6 +44,19 @@ for (const k of ['inputPath', 'projectRoot', 'outputRoot', 'pluginRoot', 'slug',
 const PEERS = Array.isArray(A.peers) ? A.peers.filter((p) => p && p.kind && p.invoke) : []
 const EX = { maxRounds: 3, ...(A.exchange || {}) }
 
+// Peer contract hardening (references/peer-runtimes.md § Trust boundary):
+// kind and model are interpolated into shell command lines by the shim, so
+// they are validated HERE at the chokepoint — charter validation alone is
+// prose and can drift. invoke templates are trusted config by design, but
+// must at least carry the {promptfile} placeholder to be usable at all.
+const RT_KIND = /^[a-z][a-z0-9-]{1,15}$/
+const RT_MODEL = /^[A-Za-z0-9._:-]{1,64}$/
+for (const p of PEERS) {
+  if (!RT_KIND.test(p.kind)) throw new Error(`flux-melange: invalid peer runtime kind ${JSON.stringify(p.kind)}`)
+  if (p.model != null && !RT_MODEL.test(String(p.model))) throw new Error(`flux-melange: invalid peer model ${JSON.stringify(p.model)} — letters/digits/._:- only`)
+  if (!String(p.invoke).includes('{promptfile}')) throw new Error(`flux-melange: peer invoke template for ${p.kind} lacks {promptfile}`)
+}
+
 const Q = A.quality
 const MODEL = {
   designAdjacent: Q === 'max' ? 'opus' : 'sonnet',
@@ -107,7 +120,7 @@ function makeRun(rt) {
 function shimWrap(rt, inner, schema) {
   return `You are a TRANSPORT SHIM for the ${rt.kind} CLI${rt.model ? ` (model ${rt.model})` : ''}. You never answer the task yourself — the external model does ALL the thinking. Your only judgment is mechanical: run, extract, relay.
 
-1. mkdir -p ${A.outputRoot}/mirrors/${rt.kind}/tmp and write the task below (the text between <<<TASK and TASK>>>, exclusive) to a uniquely named .md file there. Append this exact final paragraph:
+1. mkdir -p ${A.outputRoot}/mirrors/${rt.kind}/tmp and write the task below (the text between <<<TASK and TASK>>>, exclusive) to a uniquely named .md file there (filename: lowercase letters, digits, hyphens only — it is substituted into a shell command). Append this exact final paragraph:
    "End your reply with a single JSON object (no code fence, no prose after it) matching this JSON Schema: ${JSON.stringify(schema)}"
 2. Execute it with ONE Bash call (timeout: 600000), substituting your prompt file path for {promptfile}:
    ${rt.invoke}

--- a/skills/flux-melange-engine/workflow/melange-workflow.js
+++ b/skills/flux-melange-engine/workflow/melange-workflow.js
@@ -4,6 +4,7 @@ export const meta = {
   phases: [
     { title: 'Seed', detail: 'design seed lenses, run adjacent+distant probes' },
     { title: 'Synthesize', detail: 'eye of distance over the full ledger' },
+    { title: 'Parley', detail: 'adversarial synthesis exchange across runtimes to epistemic equilibrium' },
   ],
 }
 
@@ -23,6 +24,15 @@ export const meta = {
 // The prose spec places assay before retarget, but verify's gate and score's
 // yield both need assay scores for the round's OWN findings — this ordering
 // resolves that (assay.md's "score.md (which also re-assays)" note).
+//
+// Peer mirrors (references/peer-runtimes.md): when charter passes `peers`,
+// the SAME loop runs once per external runtime (codex, hermes) as an
+// epistemically independent mirror — own ledger, own lenses, own synthesis,
+// zero cross-contamination — with every agent call relayed through a
+// transport shim to the external CLI. After all syntheses, the Parley phase
+// (phases/parley.md) runs an adversarial exchange between per-runtime
+// advocates until a moderator detects fixed point (epistemic equilibrium);
+// residual contested items return to the orchestrator for user tie-break.
 // ============================================================================
 
 // Some hosts deliver Workflow `args` as a JSON string rather than an object.
@@ -30,6 +40,9 @@ const A = typeof args === 'string' ? JSON.parse(args) : args
 for (const k of ['inputPath', 'projectRoot', 'outputRoot', 'pluginRoot', 'slug', 'date', 'goal', 'weights', 'targetDesc', 'quality', 'budget', 'loop', 'seed', 'fusion', 'verify']) {
   if (!A || A[k] === undefined) throw new Error(`flux-melange workflow: missing charter arg "${k}" — dispatch via SKILL.md § Runtime dispatch`)
 }
+// Optional peer-mirror contract (absent = classic single-runtime run).
+const PEERS = Array.isArray(A.peers) ? A.peers.filter((p) => p && p.kind && p.invoke) : []
+const EX = { maxRounds: 3, ...(A.exchange || {}) }
 
 const Q = A.quality
 const MODEL = {
@@ -40,22 +53,12 @@ const MODEL = {
   assay: Q === 'economy' ? 'sonnet' : 'opus',
   verify: Q === 'economy' ? 'haiku' : 'sonnet',
   synthesis: Q === 'economy' ? 'sonnet' : 'opus',
+  shim: 'haiku', // transport only — the external model does the thinking
+  advocate: Q === 'economy' ? 'sonnet' : 'opus',
+  moderator: Q === 'economy' ? 'sonnet' : 'opus',
 }
 
-// ---- run state (the controller's working memory; ledger stays on disk) ----
-let slotsRemaining = A.budget.totalSlots
-let nextFindingNum = 1
-const allFindings = []            // scored finding objects, all rounds
-const clusters = {}               // cluster_id -> [finding ids]
-const lensRecords = {}            // lens id -> {domain, axioms, primitives, failure_mode, tier}
-const fusedPairs = []             // [[a,b], ...] already fused
-const resolvedDisagreements = new Set()
-const gainHistory = []            // [{round, yield, novel_cluster_rate}]
-const spiceTrail = []             // per-round audit for synthesis
-const coverageKeys = new Set()    // normalized location keys probed so far
-let openDisagreements = []        // [{location, finding_ids}]
-let haltReason = null
-
+// ---- pure helpers ----------------------------------------------------------
 const fmtId = (n) => `f-${String(n).padStart(3, '0')}`
 const heat = (f) => f.novelty * f.risk_product
 const normKey = (loc) => String(loc || '').toLowerCase().replace(/^brainstorm\s+/, '').replace(/:\d+(-\d+)?$/, '').trim()
@@ -67,6 +70,68 @@ const qualifies = (f) => {
   if (A.weights === 'taste') return f.novelty >= 2 || f.risk_product >= 6 || t >= 1
   if (A.weights === 'novelty') return f.novelty >= 1 || f.risk_product >= 6 || t >= 2
   return f.novelty >= 2 || f.risk_product >= 6 || t >= 2
+}
+
+// ---- run context ------------------------------------------------------------
+// One per runtime. The primary (claude) keeps the classic root paths so
+// fetch-findings, resume audits, and pre-peer tooling see identical artifacts;
+// mirrors nest under mirrors/{kind}/ with a lens-name suffix so generated
+// fd-* agent files in the shared .claude/agents/ namespace never collide.
+function makeRun(rt) {
+  const isPrimary = rt.kind === 'claude'
+  const base = isPrimary ? A.outputRoot : `${A.outputRoot}/mirrors/${rt.kind}`
+  return {
+    rt, isPrimary, base,
+    ledger: `${base}/heat-ledger.jsonl`,
+    lensesDir: `${base}/lenses`,
+    specTag: isPrimary ? '' : `-${rt.kind}`,
+    nameSuffix: isPrimary ? '' : `-${rt.kind.slice(0, 2)}x`,
+    pfx: isPrimary ? '' : `${rt.kind} · `,
+    slotsRemaining: A.budget.totalSlots,
+    nextFindingNum: 1,
+    allFindings: [], clusters: {}, lensRecords: {}, fusedPairs: [],
+    resolvedDisagreements: new Set(), gainHistory: [], spiceTrail: [],
+    coverageKeys: new Set(), openDisagreements: [],
+    adjacentLenses: [], distantLenses: [],
+    haltReason: null, round: 0, synth: null, failed: null,
+  }
+}
+
+// ---- shim relay for external runtimes ----------------------------------------
+// The shim is a Claude agent used as a PIPE: it executes the task on the
+// external CLI and relays the structured output verbatim. Model = haiku by
+// construction — any reasoning in the shim would contaminate the mirror's
+// epistemic independence. The schema still validates at the shim's tool-call
+// layer, so malformed external output retries hit the shim, which re-asks the
+// external CLI once before degrading.
+function shimWrap(rt, inner, schema) {
+  return `You are a TRANSPORT SHIM for the ${rt.kind} CLI${rt.model ? ` (model ${rt.model})` : ''}. You never answer the task yourself — the external model does ALL the thinking. Your only judgment is mechanical: run, extract, relay.
+
+1. mkdir -p ${A.outputRoot}/mirrors/${rt.kind}/tmp and write the task below (the text between <<<TASK and TASK>>>, exclusive) to a uniquely named .md file there. Append this exact final paragraph:
+   "End your reply with a single JSON object (no code fence, no prose after it) matching this JSON Schema: ${JSON.stringify(schema)}"
+2. Execute it with ONE Bash call (timeout: 600000), substituting your prompt file path for {promptfile}:
+   ${rt.invoke}
+3. Take the FINAL JSON object from stdout (the CLI may print logs first). If it does not parse or misses required fields, re-run ONCE with this appended to the prompt file: "Previous output was not parseable. Reply with ONLY the JSON object."
+4. Return that JSON verbatim as your structured output. Do not add, drop, merge, rescore, or reword anything in it.
+5. If the CLI is missing, fails twice, or times out: return a minimally valid object for the schema (empty arrays; any required string field = "SHIM-FAILURE: <one-line reason>") so the loop degrades gracefully.
+
+The external agent has filesystem access under ${A.projectRoot} and the task MAY ask it to write files there — that is expected; do not do the writing for it.
+
+<<<TASK
+${inner}
+TASK>>>`
+}
+
+// Every agent call in the loop flows through here: the primary dispatches
+// natively; mirrors relay through the shim with the SAME schema.
+function dispatch(R, prompt, opts) {
+  if (R.isPrimary) return agent(prompt, opts)
+  return agent(shimWrap(R.rt, prompt, opts.schema), {
+    schema: opts.schema,
+    label: `${R.rt.kind}:${opts.label}`,
+    phase: opts.phase,
+    model: MODEL.shim,
+  })
 }
 
 // ---- schemas ---------------------------------------------------------------
@@ -178,6 +243,57 @@ const SYNTH_SCHEMA = {
   },
 }
 
+const ADVOCATE_SCHEMA = {
+  type: 'object', required: ['positions', 'changed_mind'],
+  properties: {
+    positions: {
+      type: 'array',
+      items: {
+        type: 'object', required: ['topic', 'stance', 'argument'],
+        properties: {
+          topic: { type: 'string' },
+          stance: { type: 'string', enum: ['concede', 'challenge', 'affirm', 'novel'] },
+          re_runtime: { type: ['string', 'null'] },
+          argument: { type: 'string' },
+          evidence: { type: 'string' },
+        },
+      },
+    },
+    changed_mind: { type: 'boolean' },
+  },
+}
+
+const MODERATOR_SCHEMA = {
+  type: 'object', required: ['agreed', 'contested', 'changed'],
+  properties: {
+    agreed: {
+      type: 'array',
+      items: {
+        type: 'object', required: ['topic', 'statement'],
+        properties: { topic: { type: 'string' }, statement: { type: 'string' }, holders: { type: 'array', items: { type: 'string' } } },
+      },
+    },
+    contested: {
+      type: 'array',
+      items: {
+        type: 'object', required: ['topic', 'positions'],
+        properties: {
+          topic: { type: 'string' },
+          heat: { type: 'integer', minimum: 0, maximum: 9 },
+          positions: {
+            type: 'array',
+            items: {
+              type: 'object', required: ['runtime', 'argument'],
+              properties: { runtime: { type: 'string' }, argument: { type: 'string' }, evidence: { type: 'string' } },
+            },
+          },
+        },
+      },
+    },
+    changed: { type: 'boolean' },
+  },
+}
+
 // ---- prompt fragments -------------------------------------------------------
 const FINDINGS_FILE_CONTRACT = `
 For EACH lens, ALSO write one findings file to the output dir given above, structure:
@@ -195,8 +311,8 @@ actual repo files the target cites) score higher than speculation.`
 
 const severityRef = 'Severity: P0 = would corrupt/block the whole design; P1 = must fix before implementing; P2 = degrades quality; P3 = polish.'
 
-function probePrompt(directive, k, round) {
-  const dir = `${A.outputRoot}/round-${round}/probe-${k}`
+function probePrompt(R, directive, k, round) {
+  const dir = `${R.base}/round-${round}/probe-${k}`
   const base = `Run a focused lens-based review probe. Goal (north star): "${A.goal}".
 Target: ${A.inputPath}
 ${severityRef}
@@ -238,30 +354,31 @@ already-hot regions unless you see something genuinely new there: ${directive.av
 2-4 findings max; the isomorphism must be mechanistic, not decorative.`
 }
 
-// ---- Phase 1: Seed ----------------------------------------------------------
-phase('Seed')
-log(`flux-melange: ${A.slug} — budget ${slotsRemaining} slots, max ${A.loop.maxRounds} rounds, quality ${Q}`)
-
-const designRules = `For each agent output: name (fd-{domain}-{concern}), focus, persona, decision_lens,
+// ---- Phase 1: Seed (per run) --------------------------------------------------
+function designRules(R) {
+  return `For each agent output: name (fd-{domain}-{concern}${R.nameSuffix ? ` — and every name MUST end with "${R.nameSuffix}"` : ''}), focus, persona, decision_lens,
 review_areas (4-6 bullets), severity_examples (2-3 concrete), success_hints (array),
 task_context (must include this goal verbatim: "${A.goal}"), anti_overlap (array).
 Persona framing: descriptive reviewer-framework ("Apply the perspective of..."), never
 first-person "You are a...". Neutral task_context framings only.
 Steps: (1) Read the target file. (2) Write the JSON array of specs to the specs path.
 (3) Run: python3 ${A.pluginRoot}/scripts/generate-agents.py ${A.projectRoot} --from-specs {specs path} --mode=skip-existing --json
-(4) For each lens, write a lens record to ${A.outputRoot}/lenses/{name}.json:
+(4) For each lens, write a lens record to ${R.lensesDir}/{name}.json:
 {"id","kind":"base","parents":[],"domain","axioms":[3-7 load-bearing assumptions],"primitives":[units it reasons about],"failure_mode":[what it systematically misses],"findings":[]}
 (5) Return the structured output: for each lens its name/domain/axioms/primitives/failure_mode.`
+}
 
-const seedDesigns = await parallel([
-  () => agent(`You design specialized review agents (ADJACENT tier: deep expertise in the target's own
+async function seedRun(R) {
+  log(`flux-melange${R.isPrimary ? '' : ` [${R.rt.kind}]`}: ${A.slug} — budget ${R.slotsRemaining} slots, max ${A.loop.maxRounds} rounds, quality ${Q}`)
+  const seedDesigns = await parallel([
+    () => dispatch(R, `You design specialized review agents (ADJACENT tier: deep expertise in the target's own
 domain and closely adjacent fields — they catch issues requiring specialist knowledge).
 Target: ${A.targetDesc}
 File: ${A.inputPath}
 ${severityRef}
-Design ${A.seed.adjacent} agents. Specs path: ${A.projectRoot}/.claude/flux-gen-specs/${A.slug}-seed-adjacent.json
-${designRules}`, { label: 'seed-design:adjacent', phase: 'Seed', model: MODEL.designAdjacent, schema: SEED_DESIGN_SCHEMA }),
-  () => agent(`You design review agents from DISTANT knowledge domains (structural isomorphisms from
+Design ${A.seed.adjacent} agents. Specs path: ${A.projectRoot}/.claude/flux-gen-specs/${A.slug}${R.specTag}-seed-adjacent.json
+${designRules(R)}`, { label: 'seed-design:adjacent', phase: `${R.pfx}Seed`, model: MODEL.designAdjacent, schema: SEED_DESIGN_SCHEMA }),
+    () => dispatch(R, `You design review agents from DISTANT knowledge domains (structural isomorphisms from
 unrelated disciplines). Constraints: no AI-cliche domains (biology, military strategy,
 sports, information theory, thermodynamics, ecology, evolutionary biology, game theory,
 economic markets, ant colonies, neural networks, immune systems); prefer pre-modern craft
@@ -272,50 +389,52 @@ expected_isomorphisms.
 Target: ${A.targetDesc}
 File: ${A.inputPath}
 ${severityRef}
-Design ${A.seed.distant} agents. Specs path: ${A.projectRoot}/.claude/flux-gen-specs/${A.slug}-seed-distant.json
-${designRules}`, { label: 'seed-design:distant', phase: 'Seed', model: MODEL.designDistant, schema: SEED_DESIGN_SCHEMA }),
-])
+Design ${A.seed.distant} agents. Specs path: ${A.projectRoot}/.claude/flux-gen-specs/${A.slug}${R.specTag}-seed-distant.json
+${designRules(R)}`, { label: 'seed-design:distant', phase: `${R.pfx}Seed`, model: MODEL.designDistant, schema: SEED_DESIGN_SCHEMA }),
+  ])
 
-const tiers = ['adjacent', 'distant']
-seedDesigns.forEach((d, i) => {
-  if (!d) return
-  for (const l of d.lenses) lensRecords[l.name] = { ...l, tier: tiers[i] }
-})
-const adjacentLenses = seedDesigns[0] ? seedDesigns[0].lenses.map((l) => l.name) : []
-const distantLenses = seedDesigns[1] ? seedDesigns[1].lenses.map((l) => l.name) : []
-if (adjacentLenses.length + distantLenses.length === 0) throw new Error('seed design produced no lenses')
+  const tiers = ['adjacent', 'distant']
+  seedDesigns.forEach((d, i) => {
+    if (!d) return
+    for (const l of d.lenses) R.lensRecords[l.name] = { ...l, tier: tiers[i] }
+  })
+  R.adjacentLenses = seedDesigns[0] ? seedDesigns[0].lenses.map((l) => l.name) : []
+  R.distantLenses = seedDesigns[1] ? seedDesigns[1].lenses.map((l) => l.name) : []
+  if (R.adjacentLenses.length + R.distantLenses.length === 0) throw new Error(`seed design produced no lenses (${R.rt.kind})`)
 
-const seedProbeThunk = (tier, lensNames) => () =>
-  agent(`Run a lens-based review probe. Goal (north star): "${A.goal}".
+  const seedProbeThunk = (tier, lensNames) => () =>
+    dispatch(R, `Run a lens-based review probe. Goal (north star): "${A.goal}".
 Target: ${A.inputPath}
 ${severityRef}
 Apply these ${lensNames.length} lenses one at a time — each is defined in a generated agent file; read all first:
 ${lensNames.map((n) => `- ${A.projectRoot}/.claude/agents/${n}.md`).join('\n')}
-Output dir for findings files: ${A.outputRoot}/round-0/${tier}
+Output dir for findings files: ${R.base}/round-0/${tier}
 ${FINDINGS_FILE_CONTRACT}
 2-5 findings per lens, distinct and specific. Respect each lens's anti_overlap notes.`,
-    { label: `seed-probe:${tier}`, phase: 'Seed', model: MODEL.probe, schema: PROBE_SCHEMA })
+      { label: `seed-probe:${tier}`, phase: `${R.pfx}Seed`, model: MODEL.probe, schema: PROBE_SCHEMA })
 
-const seedProbeResults = (await parallel([
-  ...(adjacentLenses.length ? [seedProbeThunk('adjacent', adjacentLenses)] : []),
-  ...(distantLenses.length ? [seedProbeThunk('distant', distantLenses)] : []),
-])).filter(Boolean)
-slotsRemaining -= seedProbeResults.length
-if (!seedProbeResults.length) throw new Error('both seed probes failed')
+  const seedProbeResults = (await parallel([
+    ...(R.adjacentLenses.length ? [seedProbeThunk('adjacent', R.adjacentLenses)] : []),
+    ...(R.distantLenses.length ? [seedProbeThunk('distant', R.distantLenses)] : []),
+  ])).filter(Boolean)
+  R.slotsRemaining -= seedProbeResults.length
+  if (!seedProbeResults.length) throw new Error(`both seed probes failed (${R.rt.kind})`)
+  return seedProbeResults
+}
 
 // ---- per-round machinery ----------------------------------------------------
-async function assayRound(round, rawFindings, agentsDispatched) {
+async function assayRound(R, round, rawFindings, agentsDispatched) {
   if (!rawFindings.length) return []
-  const priorClusters = Object.entries(clusters).map(([cid, ids]) => {
-    const rep = allFindings.find((f) => f.id === ids[0])
+  const priorClusters = Object.entries(R.clusters).map(([cid, ids]) => {
+    const rep = R.allFindings.find((f) => f.id === ids[0])
     return { cluster_id: cid, example: rep ? `${rep.location}: ${rep.claim || rep.slug}` : cid }
   })
-  const idStart = nextFindingNum
-  const assay = await agent(`You are the Assayer for flux-melange round ${round}. You score findings; you never invent them.
+  const idStart = R.nextFindingNum
+  const assay = await dispatch(R, `You are the Assayer for flux-melange round ${round}. You score findings; you never invent them.
 Goal context: "${A.goal}". Target: ${A.inputPath}
 
 The round's raw findings (JSON): ${JSON.stringify(rawFindings)}
-Lens tier map: ${JSON.stringify(Object.fromEntries(Object.entries(lensRecords).map(([k, v]) => [k, v.tier])))}
+Lens tier map: ${JSON.stringify(Object.fromEntries(Object.entries(R.lensRecords).map(([k, v]) => [k, v.tier])))}
 Prior clusters (for new_cluster judgment): ${JSON.stringify(priorClusters)}
 
 For each finding, assign id f-NNN starting at ${fmtId(idStart)} (input order), then:
@@ -335,46 +454,46 @@ For each finding, assign id f-NNN starting at ${fmtId(idStart)} (input order), t
 6. DISAGREEMENTS: pairs of findings (this round or vs the ledger) at the same location with
    contradictory claims.
 
-Then APPEND one JSON line per finding to ${A.outputRoot}/heat-ledger.jsonl (schema identical to
+Then APPEND one JSON line per finding to ${R.ledger} (create the file if absent; schema identical to
 existing lines: id, round=${round}, source{kind:"lens"|"fusion",agents,parent_lenses,source_domains},
 claim, location, severity, novelty, risk{blast_radius,likelihood,product}, taste, taste_kind,
 cluster_id, convergence_refs:[], disagreement_refs:[], intersection_justification, evidence,
 status:"raw"). Also append each finding's id to the "findings" array of its lens record in
-${A.outputRoot}/lenses/{lens}.json.
+${R.lensesDir}/{lens}.json.
 
 Return the structured output (findings array with scores + disagreements).`,
-    { label: `assay:r${round}`, phase: `Round ${round}`, model: MODEL.assay, schema: ASSAY_SCHEMA })
-  if (!assay) { log(`round ${round}: assayer failed — findings kept unscored, excluded from steering`); return [] }
+    { label: `assay:r${round}`, phase: `${R.pfx}Round ${round}`, model: MODEL.assay, schema: ASSAY_SCHEMA })
+  if (!assay) { log(`${R.pfx}round ${round}: assayer failed — findings kept unscored, excluded from steering`); return [] }
   const scored = assay.findings.map((f, i) => ({
     ...f, round, status: 'raw',
     claim: f.claim || (rawFindings[i] ? rawFindings[i].claim : f.slug),
     intersection_justification: rawFindings[i] ? rawFindings[i].intersection_justification || null : null,
   }))
   for (const f of scored) {
-    nextFindingNum += 1
-    allFindings.push(f)
-    ;(clusters[f.cluster_id] = clusters[f.cluster_id] || []).push(f.id)
-    coverageKeys.add(normKey(f.location))
+    R.nextFindingNum += 1
+    R.allFindings.push(f)
+    ;(R.clusters[f.cluster_id] = R.clusters[f.cluster_id] || []).push(f.id)
+    R.coverageKeys.add(normKey(f.location))
   }
   for (const d of assay.disagreements || []) {
     const key = normKey(d.location)
-    if (!resolvedDisagreements.has(key)) openDisagreements.push({ location: d.location, finding_ids: d.finding_ids })
+    if (!R.resolvedDisagreements.has(key)) R.openDisagreements.push({ location: d.location, finding_ids: d.finding_ids })
   }
-  spiceTrail.push({ round, event: 'assay', findings: scored.length, agents_dispatched: agentsDispatched })
+  R.spiceTrail.push({ round, event: 'assay', findings: scored.length, agents_dispatched: agentsDispatched })
   return scored
 }
 
-async function verifyRound(round, scored) {
+async function verifyRound(R, round, scored) {
   if (A.verify.mode === 'off') return
   const gated = scored.filter((f) => f.status === 'raw' && (A.verify.mode === 'all' || f.emergent === true || f.novelty >= A.verify.noveltyGate || f.risk_product >= A.verify.riskGate))
   if (!gated.length) return
   const chunks = []
   for (let i = 0; i < gated.length; i += 5) chunks.push(gated.slice(i, i + 5))
-  const dropped = Math.max(0, chunks.length - Math.max(0, slotsRemaining))
-  const usable = dropped > 0 ? chunks.slice(0, Math.max(0, slotsRemaining)) : chunks
-  if (dropped > 0) log(`round ${round}: verify budget-clamped — ${dropped * 5} gated findings left raw`)
+  const dropped = Math.max(0, chunks.length - Math.max(0, R.slotsRemaining))
+  const usable = dropped > 0 ? chunks.slice(0, Math.max(0, R.slotsRemaining)) : chunks
+  if (dropped > 0) log(`${R.pfx}round ${round}: verify budget-clamped — ${dropped * 5} gated findings left raw`)
   const results = (await parallel(usable.map((chunk) => () =>
-    agent(`Verify these flux-melange findings against reality. For each: read the exact cited
+    dispatch(R, `Verify these flux-melange findings against reality. For each: read the exact cited
 location (in ${A.inputPath} or the repo file it names) and check whether the evidence supports
 the claim. Findings (JSON): ${JSON.stringify(chunk.map((f) => ({ id: f.id, claim: f.claim, location: f.location, emergent: f.emergent || false, intersection_justification: f.intersection_justification })))}
 
@@ -385,13 +504,13 @@ it OR the location/evidence does not exist. For emergent findings apply THREE ch
 suffices set emergent_keep=false but status stays upheld; (3) genuine emergent => upheld,
 emergent_keep=true.
 
-Then stamp each finding's status in ${A.outputRoot}/heat-ledger.jsonl: edit its line's
+Then stamp each finding's status in ${R.ledger}: edit its line's
 "status":"raw" to the verdict (rewrite only the status field; never edit claims).
 Return the structured results.`,
-      { label: `verify:r${round}`, phase: `Round ${round}`, model: MODEL.verify, schema: VERIFY_SCHEMA })
+      { label: `verify:r${round}`, phase: `${R.pfx}Round ${round}`, model: MODEL.verify, schema: VERIFY_SCHEMA })
   ))).filter(Boolean)
-  slotsRemaining -= usable.length
-  const byId = new Map(allFindings.map((f) => [f.id, f]))
+  R.slotsRemaining -= usable.length
+  const byId = new Map(R.allFindings.map((f) => [f.id, f]))
   for (const r of results) for (const v of r.results) {
     const f = byId.get(v.id)
     if (!f) continue
@@ -400,9 +519,9 @@ Return the structured results.`,
   }
 }
 
-function buildHeatMapAndDirectives(round) {
+function buildHeatMapAndDirectives(R, round) {
   // regions by yield density (per-round approximation: heat of new-cluster findings this round)
-  const lastRound = allFindings.filter((f) => f.round === round - 1)
+  const lastRound = R.allFindings.filter((f) => f.round === round - 1)
   const regions = {}
   for (const f of lastRound) {
     if (!f.new_cluster) continue
@@ -410,19 +529,19 @@ function buildHeatMapAndDirectives(round) {
     regions[k] = (regions[k] || 0) + heat(f)
   }
   // lens pairs: SHARED_HEAT + COMPLEMENTARITY - REDUNDANCY over all run lenses
-  const lensIds = Object.keys(lensRecords)
+  const lensIds = Object.keys(R.lensRecords)
   const findingsByLens = {}
-  for (const f of allFindings) for (const a of f.agents) (findingsByLens[a] = findingsByLens[a] || []).push(f)
+  for (const f of R.allFindings) for (const a of f.agents) (findingsByLens[a] = findingsByLens[a] || []).push(f)
   const tokenSet = (arr) => new Set((arr || []).flatMap((s) => String(s).toLowerCase().split(/[^a-z0-9]+/).filter((w) => w.length > 3)))
   const pairs = []
   for (let i = 0; i < lensIds.length; i++) for (let j = i + 1; j < lensIds.length; j++) {
     const [a, b] = [lensIds[i], lensIds[j]]
-    if (fusedPairs.some((p) => p.includes(a) && p.includes(b))) continue
+    if (R.fusedPairs.some((p) => p.includes(a) && p.includes(b))) continue
     const fa = findingsByLens[a] || [], fb = findingsByLens[b] || []
     const keysA = new Set(fa.map((f) => normKey(f.location)))
     const sharedHeat = [...new Set(fb.map((f) => normKey(f.location)))].filter((k) => keysA.has(k)).length
     if (sharedHeat < A.fusion.sharedHeatGate) continue
-    const ra = lensRecords[a], rb = lensRecords[b]
+    const ra = R.lensRecords[a], rb = R.lensRecords[b]
     const overlap = (xs, ys) => { const t = tokenSet(ys); return [...tokenSet(xs)].filter((w) => t.has(w)).length > 0 ? 1 : 0 }
     const complementarity = overlap(ra.primitives, rb.failure_mode) + overlap(rb.primitives, ra.failure_mode)
     const clustersA = new Set(fa.map((f) => f.cluster_id))
@@ -434,13 +553,13 @@ function buildHeatMapAndDirectives(round) {
 
   // directive selection (priority: PROBE-DISAGREEMENT > DEEPEN > FUSE > STEER-WIDE)
   const directives = []
-  for (const d of openDisagreements.slice(0, 1)) {
-    const fs = d.finding_ids.map((id) => allFindings.find((f) => f.id === id)).filter(Boolean)
+  for (const d of R.openDisagreements.slice(0, 1)) {
+    const fs = d.finding_ids.map((id) => R.allFindings.find((f) => f.id === id)).filter(Boolean)
     if (fs.length >= 2) directives.push({ type: 'PROBE-DISAGREEMENT', target: { location: d.location, claims: fs.slice(0, 2).map((f) => f.claim) }, rationale: 'open contradiction — adjudicate', budget_weight: 0.2 })
   }
-  const unconfirmed = Object.entries(clusters)
+  const unconfirmed = Object.entries(R.clusters)
     .map(([cid, ids]) => {
-      const members = ids.map((id) => allFindings.find((f) => f.id === id)).filter(Boolean)
+      const members = ids.map((id) => R.allFindings.find((f) => f.id === id)).filter(Boolean)
       const maxRisk = Math.max(...members.map((f) => f.risk_product))
       const confirmed = members.some((f) => f.status === 'upheld')
       const distinctLenses = new Set(members.flatMap((f) => f.agents)).size
@@ -450,7 +569,7 @@ function buildHeatMapAndDirectives(round) {
     .sort((x, y) => y.maxRisk - x.maxRisk)
   for (const c of unconfirmed.slice(0, 2 - directives.length > 0 ? 2 : 1)) {
     const top = c.members.sort((x, y) => heat(y) - heat(x))[0]
-    const lens = adjacentLenses.find((l) => !top.agents.includes(l)) || adjacentLenses[0]
+    const lens = R.adjacentLenses.find((l) => !top.agents.includes(l)) || R.adjacentLenses[0]
     if (lens) directives.push({ type: 'DEEPEN', target: { location: top.location, cluster_id: c.cid, claim: top.claim }, rationale: `risk ${c.maxRisk}, unconfirmed — confirm or refute`, lens, budget_weight: 0.35 })
   }
   let fusions = 0
@@ -459,21 +578,21 @@ function buildHeatMapAndDirectives(round) {
     directives.push({ type: 'FUSE', parents: p.pair, rationale: `shared_heat ${p.sharedHeat}, complementarity ${p.complementarity}, redundancy ${p.redundancy}`, budget_weight: 0.3 })
     fusions += 1
   }
-  const lastGain = gainHistory[gainHistory.length - 1]
+  const lastGain = R.gainHistory[R.gainHistory.length - 1]
   if (lastGain && lastGain.novel_cluster_rate >= A.loop.wideThreshold && directives.length < 4) {
-    directives.push({ type: 'STEER-WIDE', avoid: [...coverageKeys].slice(0, 12), rationale: `novel_cluster_rate ${lastGain.novel_cluster_rate.toFixed(2)} >= ${A.loop.wideThreshold} — widening still pays`, budget_weight: 0.15 })
+    directives.push({ type: 'STEER-WIDE', avoid: [...R.coverageKeys].slice(0, 12), rationale: `novel_cluster_rate ${lastGain.novel_cluster_rate.toFixed(2)} >= ${A.loop.wideThreshold} — widening still pays`, budget_weight: 0.15 })
   }
   return { directives: directives.slice(0, 4), topRegions: Object.entries(regions).sort((x, y) => y[1] - x[1]).slice(0, 5) }
 }
 
-async function probeDirectives(round, directives) {
+async function probeDirectives(R, round, directives) {
   const raw = []
   let dispatched = 0
   const thunks = directives.map((d, k) => async () => {
     if (d.type === 'FUSE') {
-      const [pa, pb] = d.parents.map((p) => lensRecords[p])
-      const fusionIdx = fusedPairs.length
-      const design = await agent(`Design ONE fused review lens combining two parents (flux-melange fusion charter).
+      const [pa, pb] = d.parents.map((p) => R.lensRecords[p])
+      const fusionIdx = R.fusedPairs.length
+      const design = await dispatch(R, `Design ONE fused review lens combining two parents (flux-melange fusion charter).
 PARENT A — ${d.parents[0]} (${pa.domain}): axioms ${JSON.stringify(pa.axioms)}; reasons about ${JSON.stringify(pa.primitives)}.
 PARENT B — ${d.parents[1]} (${pb.domain}): axioms ${JSON.stringify(pb.axioms)}; reasons about ${JSON.stringify(pb.primitives)}.
 Name the tension between them; do NOT resolve it — the fused lens INVESTIGATES where it lives.
@@ -481,37 +600,37 @@ The fused primitive is the cross-product of the parents' concerns.
 HARD CONSTRAINT to encode in the spec: report a finding ONLY if it requires BOTH parent
 perspectives; every finding must include an intersection_justification.
 Target: ${A.targetDesc} (${A.inputPath})
-Write a 1-element JSON spec array (same fd-* spec fields as other agents; name fd-fused-{concern})
-to ${A.projectRoot}/.claude/flux-gen-specs/${A.slug}-fusion-${fusionIdx}.json, run
-python3 ${A.pluginRoot}/scripts/generate-agents.py ${A.projectRoot} --from-specs ${A.projectRoot}/.claude/flux-gen-specs/${A.slug}-fusion-${fusionIdx}.json --mode=skip-existing --json
-then write the lens record (kind:"fusion", parents:${JSON.stringify(d.parents)}) to ${A.outputRoot}/lenses/{name}.json.
+Write a 1-element JSON spec array (same fd-* spec fields as other agents; name fd-fused-{concern}${R.nameSuffix ? ` ending with "${R.nameSuffix}"` : ''})
+to ${A.projectRoot}/.claude/flux-gen-specs/${A.slug}${R.specTag}-fusion-${fusionIdx}.json, run
+python3 ${A.pluginRoot}/scripts/generate-agents.py ${A.projectRoot} --from-specs ${A.projectRoot}/.claude/flux-gen-specs/${A.slug}${R.specTag}-fusion-${fusionIdx}.json --mode=skip-existing --json
+then write the lens record (kind:"fusion", parents:${JSON.stringify(d.parents)}) to ${R.lensesDir}/{name}.json.
 Return the structured output.`,
-        { label: `fuse-design:${d.parents.map((s) => s.replace(/^fd-/, '')).join('x')}`, phase: `Round ${round}`, model: MODEL.fusedDesign, schema: FUSED_DESIGN_SCHEMA })
+        { label: `fuse-design:${d.parents.map((s) => s.replace(/^fd-/, '')).join('x')}`, phase: `${R.pfx}Round ${round}`, model: MODEL.fusedDesign, schema: FUSED_DESIGN_SCHEMA })
       if (!design) return null
-      lensRecords[design.agent_name] = { domain: design.domain, axioms: design.axioms, primitives: design.primitives, failure_mode: design.failure_mode, tier: 'fusion', parents: d.parents }
-      fusedPairs.push([...d.parents])
+      R.lensRecords[design.agent_name] = { domain: design.domain, axioms: design.axioms, primitives: design.primitives, failure_mode: design.failure_mode, tier: 'fusion', parents: d.parents }
+      R.fusedPairs.push([...d.parents])
       d.lens = design.agent_name
     }
     if (d.type === 'STEER-WIDE') {
-      const design = await agent(`Design ONE new distant-domain review lens (flux-melange STEER-WIDE). Same constraints as
+      const design = await dispatch(R, `Design ONE new distant-domain review lens (flux-melange STEER-WIDE). Same constraints as
 distant seed design (no AI-cliche domains; prefer pre-modern craft/physical/non-Western
-disciplines) AND maximally distant from these already-covered domains: ${Object.values(lensRecords).map((r) => r.domain).join('; ')}.
+disciplines) AND maximally distant from these already-covered domains: ${Object.values(R.lensRecords).map((r) => r.domain).join('; ')}.
 Target: ${A.targetDesc} (${A.inputPath}). Goal: "${A.goal}".
-Write a 1-element JSON spec array (fd-* fields) to ${A.projectRoot}/.claude/flux-gen-specs/${A.slug}-wide-${round}.json, run
-python3 ${A.pluginRoot}/scripts/generate-agents.py ${A.projectRoot} --from-specs ${A.projectRoot}/.claude/flux-gen-specs/${A.slug}-wide-${round}.json --mode=skip-existing --json
-then write the lens record to ${A.outputRoot}/lenses/{name}.json. Return the structured output.`,
-        { label: `wide-design:r${round}`, phase: `Round ${round}`, model: MODEL.designDistant, schema: FUSED_DESIGN_SCHEMA })
+Write a 1-element JSON spec array (fd-* fields${R.nameSuffix ? `; name ends with "${R.nameSuffix}"` : ''}) to ${A.projectRoot}/.claude/flux-gen-specs/${A.slug}${R.specTag}-wide-${round}.json, run
+python3 ${A.pluginRoot}/scripts/generate-agents.py ${A.projectRoot} --from-specs ${A.projectRoot}/.claude/flux-gen-specs/${A.slug}${R.specTag}-wide-${round}.json --mode=skip-existing --json
+then write the lens record to ${R.lensesDir}/{name}.json. Return the structured output.`,
+        { label: `wide-design:r${round}`, phase: `${R.pfx}Round ${round}`, model: MODEL.designDistant, schema: FUSED_DESIGN_SCHEMA })
       if (!design) return null
-      lensRecords[design.agent_name] = { domain: design.domain, axioms: design.axioms, primitives: design.primitives, failure_mode: design.failure_mode, tier: 'distant' }
+      R.lensRecords[design.agent_name] = { domain: design.domain, axioms: design.axioms, primitives: design.primitives, failure_mode: design.failure_mode, tier: 'distant' }
       d.lens = design.agent_name
     }
     dispatched += 1
-    const res = await agent(probePrompt(d, k, round), { label: `probe:r${round}:${d.type.toLowerCase()}`, phase: `Round ${round}`, model: MODEL.probe, schema: PROBE_SCHEMA })
-    if (d.type === 'PROBE-DISAGREEMENT') resolvedDisagreements.add(normKey(d.target.location))
+    const res = await dispatch(R, probePrompt(R, d, k, round), { label: `probe:r${round}:${d.type.toLowerCase()}`, phase: `${R.pfx}Round ${round}`, model: MODEL.probe, schema: PROBE_SCHEMA })
+    if (d.type === 'PROBE-DISAGREEMENT') R.resolvedDisagreements.add(normKey(d.target.location))
     return res ? { directive: d, findings: res.findings } : null
   })
   const results = (await parallel(thunks)).filter(Boolean)
-  slotsRemaining -= dispatched
+  R.slotsRemaining -= dispatched
   for (const r of results) {
     for (const f of r.findings) {
       if (r.directive.type === 'FUSE' && !f.intersection_justification) continue // charter violation — drop
@@ -519,69 +638,49 @@ then write the lens record to ${A.outputRoot}/lenses/{name}.json. Return the str
     }
   }
   const failed = directives.length - results.length
-  if (failed > 0) log(`round ${round}: ${failed} probe(s) failed — proceeding with survivors`)
-  spiceTrail.push({ round, event: 'probe', directives: directives.map((d) => ({ type: d.type, rationale: d.rationale, lens: d.lens || null })), findings: raw.length, failed })
+  if (failed > 0) log(`${R.pfx}round ${round}: ${failed} probe(s) failed — proceeding with survivors`)
+  R.spiceTrail.push({ round, event: 'probe', directives: directives.map((d) => ({ type: d.type, rationale: d.rationale, lens: d.lens || null })), findings: raw.length, failed })
   return raw
 }
 
-function scoreRound(round, scored) {
+function scoreRound(R, round, scored) {
   const newClusters = new Set(scored.filter((f) => f.new_cluster).map((f) => f.cluster_id)).size
   const roundYield = scored.filter((f) => f.status === 'upheld' && f.new_cluster && qualifies(f)).length
   const rate = scored.length ? newClusters / scored.length : 0
-  gainHistory.push({ round, yield: roundYield, novel_cluster_rate: Number(rate.toFixed(2)) })
-  openDisagreements = openDisagreements.filter((d) => !resolvedDisagreements.has(normKey(d.location)))
+  R.gainHistory.push({ round, yield: roundYield, novel_cluster_rate: Number(rate.toFixed(2)) })
+  R.openDisagreements = R.openDisagreements.filter((d) => !R.resolvedDisagreements.has(normKey(d.location)))
   // continue predicate — halt precedence: BUDGET > DRY > CEILING (score.md § Step 4)
-  if (slotsRemaining < A.budget.roundCostFloor) haltReason = 'BUDGET'
-  else if (round + 1 > A.loop.minRounds && roundYield <= A.loop.diminishingThreshold) haltReason = 'DRY'
-  else if (round + 1 > A.loop.maxRounds) haltReason = 'CEILING'
-  log(`round ${round}: yield ${roundYield}, novel_cluster_rate ${rate.toFixed(2)}, slots left ${slotsRemaining}${haltReason ? ` — HALT ${haltReason}` : ''}`)
-  return haltReason === null
+  if (R.slotsRemaining < A.budget.roundCostFloor) R.haltReason = 'BUDGET'
+  else if (round + 1 > A.loop.minRounds && roundYield <= A.loop.diminishingThreshold) R.haltReason = 'DRY'
+  else if (round + 1 > A.loop.maxRounds) R.haltReason = 'CEILING'
+  log(`${R.pfx}round ${round}: yield ${roundYield}, novel_cluster_rate ${rate.toFixed(2)}, slots left ${R.slotsRemaining}${R.haltReason ? ` — HALT ${R.haltReason}` : ''}`)
+  return R.haltReason === null
 }
 
-// ---- round 0: assay + verify + score the seed --------------------------------
-const seedRaw = seedProbeResults.flatMap((r) => r.findings)
-const seedScored = await assayRound(0, seedRaw, seedProbeResults.length)
-await verifyRound(0, seedScored)
-scoreRound(0, seedScored)
+// ---- Phase 7: synthesize (per run) --------------------------------------------
+async function synthesizeRun(R) {
+  const frontier = R.allFindings.filter((f) => f.status !== 'refuted').sort((x, y) => heat(y) - heat(x)).slice(0, 10)
+  const convergence = {}
+  for (const [cid, ids] of Object.entries(R.clusters)) {
+    if (ids.length < 2) continue
+    const lenses = new Set(ids.flatMap((id) => (R.allFindings.find((f) => f.id === id) || { agents: [] }).agents))
+    if (lenses.size >= 2) convergence[cid] = ids
+  }
+  const fusionStats = { attempted: R.fusedPairs.length, emergent: R.allFindings.filter((f) => f.emergent === true && f.status !== 'refuted').length }
 
-// ---- the loop -----------------------------------------------------------------
-let round = 0
-while (haltReason === null) {
-  round += 1
-  if (round > A.loop.maxRounds) { haltReason = 'CEILING'; break }
-  const { directives } = buildHeatMapAndDirectives(round)
-  if (!directives.length) { haltReason = 'DRY'; log(`round ${round}: controller found no directives — DRY`); break }
-  log(`round ${round}: directives — ${directives.map((d) => d.type).join(', ')}`)
-  const raw = await probeDirectives(round, directives)
-  const scored = await assayRound(round, raw, directives.length)
-  await verifyRound(round, scored)
-  if (!scoreRound(round, scored)) break
-}
-
-// ---- Phase 7: synthesize --------------------------------------------------------
-phase('Synthesize')
-const frontier = allFindings.filter((f) => f.status !== 'refuted').sort((x, y) => heat(y) - heat(x)).slice(0, 10)
-const convergence = {}
-for (const [cid, ids] of Object.entries(clusters)) {
-  if (ids.length < 2) continue
-  const lenses = new Set(ids.flatMap((id) => (allFindings.find((f) => f.id === id) || { agents: [] }).agents))
-  if (lenses.size >= 2) convergence[cid] = ids
-}
-const fusionStats = { attempted: fusedPairs.length, emergent: allFindings.filter((f) => f.emergent === true && f.status !== 'refuted').length }
-
-const synth = await agent(`You are writing the synthesis for a flux-melange spice-loop review — the eye of distance.
+  const synth = await dispatch(R, `You are writing the synthesis for a flux-melange spice-loop review — the eye of distance.
 
 Target: ${A.targetDesc}    File: ${A.inputPath}
 Goal: ${A.goal}    Weights: ${A.weights}
-The loop ran ${round + 1} rounds (0-${round}) and halted: ${haltReason}.
+The loop ran ${R.round + 1} rounds (0-${R.round}) and halted: ${R.haltReason}.
 
-Read the full ledger at ${A.outputRoot}/heat-ledger.jsonl and the lens records in ${A.outputRoot}/lenses/.
+Read the full ledger at ${R.ledger} and the lens records in ${R.lensesDir}/.
 Controller state (script-computed; the on-disk ledger rows carry empty ref arrays in workflow mode):
-- clusters: ${JSON.stringify(clusters)}
+- clusters: ${JSON.stringify(R.clusters)}
 - cross-lens convergent clusters: ${JSON.stringify(convergence)}
-- open disagreements at halt: ${JSON.stringify(openDisagreements)}
-- gain history: ${JSON.stringify(gainHistory)}
-- spice trail: ${JSON.stringify(spiceTrail)}
+- open disagreements at halt: ${JSON.stringify(R.openDisagreements)}
+- gain history: ${JSON.stringify(R.gainHistory)}
+- spice trail: ${JSON.stringify(R.spiceTrail)}
 - fusion stats: ${JSON.stringify(fusionStats)}
 - frontier (triage-grade): ${JSON.stringify(frontier.map((f) => f.id))}
 
@@ -618,34 +717,179 @@ Optionally a single "If you read one thing" = argmax(heat), |taste| tiebreaker.
 
 Write direct technical prose. Name lenses when attributing. Rank by HEAT (novelty × risk).
 
-Write the report to ${A.outputRoot}/${A.date}-synthesis.md with YAML frontmatter:
+Write the report to ${R.base}/${A.date}-synthesis.md with YAML frontmatter:
 artifact_type: melange-synthesis / method: flux-melange / target / target_description / goal /
-weights / rounds_run: ${round + 1} / halt_reason: ${haltReason} / total_fusions: ${fusionStats.attempted} /
-emergent_findings: ${fusionStats.emergent} / date: ${A.date}
+weights / rounds_run: ${R.round + 1} / halt_reason: ${R.haltReason} / total_fusions: ${fusionStats.attempted} /
+emergent_findings: ${fusionStats.emergent} / runtime: ${R.rt.kind} / date: ${A.date}
 Include caveats (failed probes, budget-clamped verification, regions never reached).
 
-ALSO write ${A.outputRoot}/surfaced.jsonl — one JSON line per finding appearing in ANY of the
+ALSO write ${R.base}/surfaced.jsonl — one JSON line per finding appearing in ANY of the
 five views: {"id","views":[subset of frontier|fusion|taste|convergence|disagreement|if-you-read-one-thing],"novelty","risk":{"product"},"taste","claim","location","status"}. The surfaced set is the UNION
 of the five views; refuted findings never appear.
 
-AND write ${A.outputRoot}/run-manifest.json: {"rounds","halt_reason","gain_history","spice_trail","slots_spent":${A.budget.totalSlots - slotsRemaining},"directive_history"} from the controller state above.
+AND write ${R.base}/run-manifest.json: {"runtime":"${R.rt.kind}","rounds","halt_reason","gain_history","spice_trail","slots_spent":${A.budget.totalSlots - R.slotsRemaining},"directive_history"} from the controller state above.
 
 Return the structured output.`,
-  { label: 'synthesis', phase: 'Synthesize', model: MODEL.synthesis, schema: SYNTH_SCHEMA })
+    { label: 'synthesis', phase: `${R.pfx}Synthesize`, model: MODEL.synthesis, schema: SYNTH_SCHEMA })
+  R.synth = synth
+  R.frontierTop = frontier[0] || null
+  R.fusionStats = fusionStats
+}
+
+// ---- full loop for one runtime ------------------------------------------------
+async function runMelange(R) {
+  const seedProbeResults = await seedRun(R)
+  const seedRaw = seedProbeResults.flatMap((r) => r.findings)
+  const seedScored = await assayRound(R, 0, seedRaw, seedProbeResults.length)
+  await verifyRound(R, 0, seedScored)
+  scoreRound(R, 0, seedScored)
+
+  while (R.haltReason === null) {
+    R.round += 1
+    if (R.round > A.loop.maxRounds) { R.haltReason = 'CEILING'; break }
+    const { directives } = buildHeatMapAndDirectives(R, R.round)
+    if (!directives.length) { R.haltReason = 'DRY'; log(`${R.pfx}round ${R.round}: controller found no directives — DRY`); break }
+    log(`${R.pfx}round ${R.round}: directives — ${directives.map((d) => d.type).join(', ')}`)
+    const raw = await probeDirectives(R, R.round, directives)
+    const scored = await assayRound(R, R.round, raw, directives.length)
+    await verifyRound(R, R.round, scored)
+    if (!scoreRound(R, R.round, scored)) break
+  }
+
+  await synthesizeRun(R)
+  return R
+}
+
+// ---- Phases 1..7: run all runtimes (primary + independent mirrors) --------------
+phase('Seed')
+const runs = [makeRun({ kind: 'claude' }), ...PEERS.map((p) => makeRun(p))]
+if (PEERS.length) log(`peer mirrors: ${PEERS.map((p) => `${p.kind}${p.model ? ` (${p.model})` : ''}`).join(', ')} — independent loops, no cross-contamination until Parley`)
+
+await parallel(runs.map((R) => () =>
+  runMelange(R).catch((e) => { R.failed = String((e && e.message) || e); return R })
+))
+
+const primary = runs[0]
+if (primary.failed) throw new Error(`primary (claude) melange loop failed: ${primary.failed}`)
+const mirrorCaveats = runs.slice(1).filter((R) => R.failed).map((R) => `${R.rt.kind} mirror failed: ${R.failed}`)
+
+// ---- Phase 7.5: Parley — adversarial exchange to epistemic equilibrium ---------
+// Spec: phases/parley.md. Each surviving runtime fields an ADVOCATE (native for
+// the primary, shim-relayed for mirrors — the external model argues its own
+// case). A native MODERATOR merges positions after each exchange round and
+// detects the fixed point: a round in which no advocate concedes, introduces
+// new evidence, or surfaces a novel synthesis. Residual contested items are
+// returned for user tie-break (the orchestrator owns AskUserQuestion).
+let equilibrium = null
+const parties = runs.filter((R) => !R.failed && R.synth && R.synth.synthesis_path)
+if (runs.length > 1 && parties.length > 1) {
+  phase('Parley')
+  const eqPath = `${A.outputRoot}/equilibrium.md`
+  const disPath = `${A.outputRoot}/disagreements.jsonl`
+  let table = null
+  let exRound = 0
+  let changed = true
+  while (changed && exRound < EX.maxRounds) {
+    exRound += 1
+    const positions = (await parallel(parties.map((R) => () => {
+      const others = parties.filter((x) => x !== R)
+      const prompt = `You are the ${R.rt.kind} ADVOCATE in an adversarial synthesis exchange (round ${exRound} of at most ${EX.maxRounds}).
+Independent review loops examined the same target; each produced its own synthesis.
+Your synthesis (your prior positions): ${R.synth.synthesis_path}
+Peer syntheses: ${others.map((x) => `${x.rt.kind}: ${x.synth.synthesis_path}`).join('; ')}
+Target under review: ${A.inputPath} (read it and any repo files needed to ground arguments).
+Prior consensus table from the moderator: ${table ? JSON.stringify(table) : 'none — first exchange round'}
+
+Read all syntheses. For every materially disputed or unique claim across them, output a position:
+- "concede": you now accept a peer claim your synthesis missed or contradicted — say what changed your mind
+- "challenge": you dispute a peer claim — MUST cite concrete evidence from the target/repo
+- "affirm": you stand by your claim against a challenge — MUST introduce NEW evidence, never repetition
+- "novel": a genuinely new insight the collision of syntheses exposed
+Rules: a position without evidence is void; rhetorical repetition is void; concede when the
+evidence goes against you. This exchange seeks EPISTEMIC EQUILIBRIUM, not victory — an advocate
+that concedes a weak claim strengthens its credibility on the strong ones.
+Set changed_mind=true iff this round you conceded anything, introduced new evidence, or found a novel insight.`
+      return dispatch(R, prompt, { label: `advocate:r${exRound}`, phase: 'Parley', model: MODEL.advocate, schema: ADVOCATE_SCHEMA })
+        .then((res) => (res ? { runtime: R.rt.kind, ...res } : null))
+    }))).filter(Boolean)
+
+    if (!positions.length) { changed = false; break }
+
+    table = await agent(`You are the MODERATOR of an adversarial synthesis exchange (flux-melange Parley, round ${exRound}).
+You merge positions; you never invent arguments or take sides.
+This round's advocate positions (JSON): ${JSON.stringify(positions)}
+Prior consensus table: ${table ? JSON.stringify(table) : 'none — first round'}
+Syntheses for reference: ${parties.map((x) => `${x.rt.kind}: ${x.synth.synthesis_path}`).join('; ')}
+
+1. AGREED: claims all advocates now hold (including via concession this round). Merge into one
+   statement each; record holders.
+2. CONTESTED: claims still under live dispute. For each: every runtime's current argument +
+   evidence, and a heat score 0-9 (how consequential the disagreement is for the target).
+   Positions that are pure repetition of a prior round carry no weight — note them as stale.
+3. changed: true iff any advocate reported changed_mind=true OR the table materially differs
+   from the prior table (new agreed items, new/retired contested items, or new evidence).
+   changed=false means the exchange has reached its fixed point (epistemic equilibrium).
+
+Write ${eqPath} (overwrite): YAML frontmatter (artifact_type: melange-equilibrium / date: ${A.date} /
+runtimes: ${JSON.stringify(parties.map((x) => x.rt.kind))} / exchange_rounds: ${exRound} / equilibrium: {true iff changed=false})
+then sections: ## Consensus (agreed, with holders), ## Contested (per topic: each side's argument
+and evidence, heat, ordered by heat desc), ## Exchange log (one line per round: concessions,
+new evidence, novel insights).
+Write ${disPath} (overwrite): one JSON line per contested topic: {"topic","heat","positions":[{"runtime","argument","evidence"}]}.
+Return the structured output.`,
+      { label: `moderator:r${exRound}`, phase: 'Parley', model: MODEL.moderator, schema: MODERATOR_SCHEMA })
+
+    if (!table) { log(`parley round ${exRound}: moderator failed — halting exchange with last known state`); changed = false; break }
+    changed = table.changed
+    log(`parley round ${exRound}: ${table.agreed.length} agreed, ${table.contested.length} contested${changed ? '' : ' — EQUILIBRIUM'}`)
+  }
+  equilibrium = {
+    rounds: exRound,
+    reached: !changed,
+    agreed_count: table ? table.agreed.length : 0,
+    contested: table ? table.contested : [],
+    equilibrium_path: eqPath,
+    disagreements_path: disPath,
+    parties: parties.map((x) => x.rt.kind),
+  }
+} else if (runs.length > 1) {
+  mirrorCaveats.push('parley skipped — fewer than 2 surviving syntheses')
+}
+
+// ---- report ---------------------------------------------------------------------
+const runReport = (R) => ({
+  runtime: R.rt.kind,
+  model: R.rt.model || null,
+  failed: R.failed,
+  rounds_run: R.failed ? null : R.round + 1,
+  halt_reason: R.haltReason,
+  slots_spent: A.budget.totalSlots - R.slotsRemaining,
+  findings_total: R.allFindings.length,
+  upheld: R.allFindings.filter((f) => f.status === 'upheld').length,
+  refuted: R.allFindings.filter((f) => f.status === 'refuted').length,
+  fusions: R.fusionStats || { attempted: R.fusedPairs.length, emergent: 0 },
+  synthesis_path: R.synth ? R.synth.synthesis_path : null,
+  ledger_path: R.ledger,
+})
 
 return {
   slug: A.slug,
-  rounds_run: round + 1,
-  halt_reason: haltReason,
-  slots_spent: A.budget.totalSlots - slotsRemaining,
-  findings_total: allFindings.length,
-  upheld: allFindings.filter((f) => f.status === 'upheld').length,
-  refuted: allFindings.filter((f) => f.status === 'refuted').length,
-  fusions: fusionStats,
-  gain_history: gainHistory,
-  top_finding: synth ? synth.top_finding : (frontier[0] ? `${frontier[0].id}: ${frontier[0].claim}` : null),
-  synthesis_path: synth ? synth.synthesis_path : null,
-  surfaced_count: synth ? synth.surfaced_count : 0,
-  caveats: synth ? synth.caveats || [] : ['synthesis agent failed — ledger is intact; rerun synthesis from heat-ledger.jsonl'],
-  ledger_path: `${A.outputRoot}/heat-ledger.jsonl`,
+  rounds_run: primary.round + 1,
+  halt_reason: primary.haltReason,
+  slots_spent: A.budget.totalSlots - primary.slotsRemaining,
+  findings_total: primary.allFindings.length,
+  upheld: primary.allFindings.filter((f) => f.status === 'upheld').length,
+  refuted: primary.allFindings.filter((f) => f.status === 'refuted').length,
+  fusions: primary.fusionStats,
+  gain_history: primary.gainHistory,
+  top_finding: primary.synth ? primary.synth.top_finding : (primary.frontierTop ? `${primary.frontierTop.id}: ${primary.frontierTop.claim}` : null),
+  synthesis_path: primary.synth ? primary.synth.synthesis_path : null,
+  surfaced_count: primary.synth ? primary.synth.surfaced_count : 0,
+  caveats: [
+    ...(primary.synth ? primary.synth.caveats || [] : ['synthesis agent failed — ledger is intact; rerun synthesis from heat-ledger.jsonl']),
+    ...mirrorCaveats,
+  ],
+  ledger_path: primary.ledger,
+  peers: PEERS.length ? runs.slice(1).map(runReport) : undefined,
+  equilibrium,
 }


### PR DESCRIPTION
## Summary

Extends `/flux-melange` with `--peers` — the same heat-ledger loop runs as **epistemically independent mirrors** on external agent runtimes, then the syntheses **argue to equilibrium**:

- **Runtime detection** (`scripts/detect-runtimes.sh`): `--peers=auto` mirrors on whatever is installed (Codex CLI, Hermes Agent); explicit lists (`codex:gpt-5.6-sol,hermes`) skip-and-log undetected runtimes. Auth is deliberately not probed headlessly — an unauthenticated CLI degrades at probe time via the shim contract.
- **Transport shim**: workflow scripts can only spawn Claude agents, so each mirror call is relayed by a haiku agent whose whole charter is *run the task on the external CLI, relay the structured output verbatim*. Haiku by construction — transport too dumb to contaminate the mirror's independence. Same JSON Schemas validate both paths.
- **Isolation**: mirrors get their own artifact tree (`mirrors/{kind}/`), own ledgers/lens records, and per-runtime lens-name suffixes so generated `fd-*` agents in the shared `.claude/agents/` namespace never collide. No cross-contamination until Parley.
- **Parley** (`phases/parley.md`): per-runtime advocates exchange `concede / challenge / affirm / novel` positions (evidence required, repetition void); a neutral moderator merges the consensus table each round and detects the **fixed point** — no concessions, no new evidence, no novel insights → *epistemic equilibrium*. Residual contested topics (with heat scores and per-runtime attribution) return to the orchestrator, which tie-breaks via `AskUserQuestion` and appends rulings to `equilibrium.md`.
- **Failure posture** matches the plugin: dead mirror → caveat (primary unaffected); <2 surviving syntheses → Parley skipped; primary death still fails the run.

Invoke templates live in `defaults.yaml` (not code) so CLI flag drift is a config fix.

## Why exchange instead of merge

A single reconciling agent launders disagreement — the merger's priors win every close call. The exchange keeps each runtime's position alive and attributed until it is genuinely conceded (evidence, not authority) or explicitly surfaced as contested. What's still contested at equilibrium is the run's most valuable residue, and it goes to the user.

## Testing

- `node --check` on the workflow script (wrapped in the async runtime context)
- `bash -n` + live run of `detect-runtimes.sh` (detected codex 0.144.4 + hermes 0.18.2 on a dev Mac)
- YAML parse of `defaults.yaml`; plugin manifest parse; structural counts unchanged (3 skills, 8 commands)
- Classic single-runtime path is behaviorally unchanged (no `peers` arg → identical flow, primary keeps classic root paths for resume/fetch-findings compatibility)
- Not yet exercised end-to-end with live mirrors — needs a real `--peers=auto` run before release

Tracking: workspace bead mk-7dg

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NDP6pbKewPCe532Zdxn1JM