### PR TITLE
Demote the flux commands, following the split the estate already makes

### DIFF
--- a/commands/fetch-findings.md
+++ b/commands/fetch-findings.md
@@ -2,6 +2,7 @@
 name: fetch-findings
 description: Fetch peer findings from a flux-drive review — inspect what agents have shared during a parallel review.
 allowed-tools: Bash, Read
+disable-model-invocation: true
 ---
 
 # Fetch Peer Findings

--- a/commands/flux-agent.md
+++ b/commands/flux-agent.md
@@ -3,6 +3,7 @@ name: flux-agent
 description: "Manage flux agent registry — index/backfill/stats/prune/promote/record. Lifecycle for review agents with quality tiers + domain indexing."
 user-invocable: true
 argument-hint: "<index|backfill|stats|prune|promote|record> [options]"
+disable-model-invocation: true
 ---
 
 # Flux-Agent — Agent Lifecycle Manager

--- a/commands/flux-drive.md
+++ b/commands/flux-drive.md
@@ -4,6 +4,7 @@ description: "Intelligent document review — triages relevant agents, runs in b
 user-invocable: true
 codex-aliases: [flux-drive]
 argument-hint: "[path to file or directory] [--mode=review|research] [--phase=<phase>]"
+disable-model-invocation: true
 ---
 
 Use the `interflux:flux-engine` skill to review the document or directory specified by the user. Pass the file or directory path as context. Default mode is `review`. Pass `--mode=research` for multi-agent research (or use `/interflux:flux-research` which auto-sets research mode).

--- a/commands/flux-explore.md
+++ b/commands/flux-explore.md
@@ -4,6 +4,7 @@ description: Autonomous multi-round semantic exploration — agents from progres
 user-invocable: true
 codex-aliases: [flux-explore]
 argument-hint: "<target description> [--rounds=3] [--agents-per-round=5] [--teams]"
+disable-model-invocation: true
 ---
 
 # Flux-Explore — Autonomous Semantic Space Exploration

--- a/commands/flux-gen.md
+++ b/commands/flux-gen.md
@@ -4,6 +4,7 @@ description: Generate review agents from task prompts via LLM design
 user-invocable: true
 codex-aliases: [flux-gen]
 argument-hint: "[task prompt text] [--from-specs path]"
+disable-model-invocation: true
 ---
 
 # Flux-Gen — Review Agent Generator

--- a/commands/flux-melange.md
+++ b/commands/flux-melange.md
@@ -4,6 +4,7 @@ description: "Goal-seeking spice loop — adaptive review rounds steer toward th
 user-invocable: true
 codex-aliases: [flux-melange]
 argument-hint: "<path, dir, or inline text> [--goal=\"...\"] [--weights=balanced|risk-hunt|taste|novelty] [--max-rounds=N] [--budget=N] [--quality=economy|balanced|max] [--fusion=auto|N|off] [--verify=auto|off|all] [--peers=off|auto|codex[:model],hermes[:model]] [--exchange-rounds=N] [--interactive]"
+disable-model-invocation: true
 ---
 
 Use the `interflux:flux-melange-engine` skill to run a goal-seeking, multi-round deep review of the target. Pass `$ARGUMENTS` through verbatim. The skill owns charter parsing, the seed round, the heat-ledger control loop (assay → retarget → probe → verify → score → loop gate), runtime lens fusion, and the surfacing-first synthesis.

--- a/commands/flux-research.md
+++ b/commands/flux-research.md
@@ -4,6 +4,7 @@ description: "Multi-agent research — triages agents, dispatches in parallel, s
 user-invocable: true
 codex-aliases: [flux-research]
 argument-hint: "[research question]"
+disable-model-invocation: true
 ---
 
 Use the `interflux:flux-engine` skill with `mode=research` to research the question specified by the user. Pass the research question as context.

--- a/commands/flux-review.md
+++ b/commands/flux-review.md
@@ -4,6 +4,7 @@ description: "Multi-track deep review — agents across semantic distance (adjac
 user-invocable: true
 codex-aliases: [flux-review]
 argument-hint: "<path, topic, or inline text> [--tracks=auto|2|3|4] [--creative] [--quality=balanced|economy|max] [--interactive]"
+disable-model-invocation: true
 ---
 
 Use the `interflux:flux-review-engine` skill to run a multi-track deep review of the target. Pass `$ARGUMENTS` through verbatim. The skill handles per-track agent design across semantic-distance tiers, parallel flux-drive review dispatch, cross-track synthesis, and the final report.


### PR DESCRIPTION
Demote the flux commands, following the split the estate already makes

zklw measures 28,585 chars of advertised plugin surface against a 28,500 warn
band, and has been inside that band since the ceiling was set on 2026-07-26
(both machines read 29,360 and 29,496 then).

Raising the ceiling is not available, and not because it would be distasteful --
rig-budget-eval.py already contains the decision:

  "Rejected: a per-machine ceiling set from what a machine currently spends is
   the same mistake as widening the warn band to make today.s reading green.
   The threshold would then describe the rig instead of constraining it."

So it comes down instead, and interflux is where, because it is the outlier
against a convention this estate already follows without stating it:

  clavain      commands live=22 dem=35   agents live=13 dem=0
  interspect   commands live=7  dem=11   agents live=0  dem=0
  interbrowse  commands live=0  dem=8    agents live=2  dem=0
  interflux    commands live=8  dem=0    agents live=25 dem=0

54 commands across the estate carry disable-model-invocation and NOT ONE agent
does. That split is the right one: a command is typed by a human, so advertising
it for model invocation buys nothing, while an agent is spawned BY the model, so
demoting one would break the spawning. interflux had never been brought in line.

The 25 agents are deliberately untouched. flux-drive and flux-melange spawn them
by name, and that is exactly the case the convention protects.

Nothing becomes unreachable. /interflux:flux-melange still works when typed --
user-invocable: true is unchanged on all eight -- and the routing that says to
reach for it lives in CLAUDE.md, which is loaded independently of this listing.

Effect: -2,432 chars, 28,585 -> 26,153, which is 2,347 under the warn band and
3,847 under the ceiling. It lands in the measured number when the plugin is next
published; the cache is never edited directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
