### PR TITLE
chore(release): interflux 0.2.86

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "interflux",
-  "version": "0.2.85",
+  "version": "0.2.86",
   "description": "Multi-agent review and research with scored triage, domain detection, content slicing, intermediate finding sharing, and knowledge injection. 17 agents (12 review + 5 research), 8 commands (incl. flux-melange \u2014 a goal-seeking adaptive review loop with lens fusion and novelty/risk/taste scoring), 3 skills (flux-engine, flux-review-engine, flux-melange-engine), 2 MCP servers (exa, openrouter-dispatch). Companion plugin for Clavain.",
   "author": {
     "name": "mistakeknot"

--- a/kimi.plugin.json
+++ b/kimi.plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "interflux",
-  "version": "0.2.85",
+  "version": "0.2.86",
   "description": "Multi-agent review and research with scored triage, domain detection, content slicing, intermediate finding sharing, and knowledge injection. 17 agents (12 review + 5 research), 8 commands (incl. flux-melange — a goal-seeking adaptive review loop with lens fusion and novelty/risk/taste scoring), 3 skills (flux-engine, flux-review-engine, flux-melange-engine), 2 MCP servers (exa, openrouter-dispatch). Companion plugin for Clavain.",
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION
Ships the command demotion from #21. Version bump plus the regenerated kimi
manifest in one commit, which is what the pre-commit parity gate requires — the
first publish attempt failed exactly there, with plugin.json at 0.2.86 and
kimi.plugin.json still at 0.2.85.

Already synced to the marketplace from the signer machine; this is the source
side of that, and it cannot go direct because main is protected.

Measured effect on the machine that installed it: the advertisement budget on
zklw went 28,585 → 27,445, out of the warn band (WARN_AT=28,500) and 2,555 under
the ceiling. All 25 agents are untouched — a command is typed by a human, an
agent is spawned by the model, and demoting an agent would break the spawning.
